### PR TITLE
fix: fall back to raw bytes when manifest retrieval fails

### DIFF
--- a/ui/src/api/bee.ts
+++ b/ui/src/api/bee.ts
@@ -289,6 +289,14 @@ export const beeApi = {
     })
   },
 
+  downloadBytes: async (hash: string): Promise<Blob> => {
+    const r = await fetch(`${getBeeUrl()}/bytes/${hash}`)
+
+    if (!r.ok) throw new Error(`Download failed: ${r.status}`)
+
+    return r.blob()
+  },
+
   uploadFile: async (file: File, stampId: string): Promise<UploadResult> => {
     return fetch(`${getBeeUrl()}/bzz`, {
       method: 'POST',

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -690,7 +690,15 @@ function RetrieveModal({ onClose }: { onClose: () => void }) {
     setLoading(true)
     setError(null)
     try {
-      const blob = await beeApi.downloadFile(h)
+      let blob: Blob
+
+      try {
+        blob = await beeApi.downloadFile(h)
+      } catch {
+        // Manifest download failed — try raw bytes fallback
+        blob = await beeApi.downloadBytes(h)
+      }
+
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url


### PR DESCRIPTION
## Summary
- When retrieving content by Swarm hash, the app now tries `/bzz/` (manifest) first, then falls back to `/bytes/` (raw data) if that returns 404
- Added `downloadBytes` method to `beeApi`
- Handles cases where user enters a raw chunk hash instead of a manifest reference

## Test plan
- [x] Enter a manifest hash → downloads as before
- [x] Enter a raw data hash → falls back to `/bytes/`, downloads successfully
- [x] Enter an invalid hash → shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)