### PR TITLE
fix: run build before package/make/publish to prevent stale bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npm run check:types    # TypeScript type check
 npm run test:unit      # Run Jest unit tests (verbose)
 cd ui && npm test      # Run Vitest tests for UI utility functions
 
-# Packaging
+# Packaging (all three run `npm run build` first automatically)
 npm run package        # Package Electron app (no installer)
 npm run make           # Create platform installers (DMG, EXE, DEB, RPM, ZIP)
 npm run publish        # Publish to GitHub releases
@@ -37,6 +37,8 @@ npm run clean          # Remove dist/ and out/
 npm run purge:data     # Clear app data folder
 npm run purge:logs     # Clear app logs folder
 ```
+
+**Packaging note:** When installing a packaged build to `/Applications/`, always `rm -rf /Applications/Nook.app` before copying — `cp -R` over an existing `.app` may not fully replace the asar resource file, resulting in stale UI code.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "main": "dist/desktop/src/index.js",
   "scripts": {
     "start": "concurrently -n \"desktop,ui\" \"cross-env-shell NODE_ENV=development 'npm run clean && npm run build && electron-forge start'\" \"cd ui && npm start\"",
-    "package": "electron-forge package",
-    "make": "electron-forge make",
-    "publish": "electron-forge publish",
+    "package": "npm run build && electron-forge package",
+    "make": "npm run build && electron-forge make",
+    "publish": "npm run build && electron-forge publish",
     "publish:mac:arm64": "electron-forge publish --platform=darwin --arch=arm64",
     "publish:mac:x64": "electron-forge publish --platform=darwin --arch=x64",
     "publish:linux:arm64": "electron-forge publish --platform=linux --arch=arm64",


### PR DESCRIPTION
## Summary

- `package`, `make`, and `publish` scripts now run `npm run build` first
- Previously they only ran `electron-forge` directly, which bundled whatever was in `dist/` — potentially stale UI code from an earlier build
- Documents the macOS `.app` copy gotcha in CLAUDE.md

## Changed files

| File | Change |
|------|--------|
| `package.json` | Prepend `npm run build &&` to package/make/publish scripts |
| `CLAUDE.md` | Update packaging docs, add note about `rm -rf` before `cp -R` |

AI-assisted implementation.