### PR TITLE
fix: align dev server port with Vite proxy

### DIFF
--- a/src/port.ts
+++ b/src/port.ts
@@ -5,9 +5,23 @@ export const port = {
   value: -1,
 }
 
-const DEFAULT_PORT = 3054
+const DEFAULT_PORT = 3000
 
 export async function findFreePort() {
+  const isDev = process.env.NODE_ENV === 'development'
+
+  if (isDev) {
+    const free = await testPort(DEFAULT_PORT)
+    if (!free) {
+      throw new Error(
+        `Port ${DEFAULT_PORT} is already in use. Stop the other process and try again.`,
+      )
+    }
+    port.value = DEFAULT_PORT
+    logger.info(`Dev mode: using port ${DEFAULT_PORT}`)
+    return
+  }
+
   logger.info('Finding free port...')
   for (let i = DEFAULT_PORT; i < 5000; i++) {
     const free = await testPort(i)

--- a/src/port.ts
+++ b/src/port.ts
@@ -12,13 +12,13 @@ export async function findFreePort() {
 
   if (isDev) {
     const free = await testPort(DEFAULT_PORT)
+
     if (!free) {
-      throw new Error(
-        `Port ${DEFAULT_PORT} is already in use. Stop the other process and try again.`,
-      )
+      throw new Error(`Port ${DEFAULT_PORT} is already in use. Stop the other process and try again.`)
     }
     port.value = DEFAULT_PORT
     logger.info(`Dev mode: using port ${DEFAULT_PORT}`)
+
     return
   }
 


### PR DESCRIPTION
## Summary
- Default port changed from 3054 to 3000 (matches Vite proxy config in `ui/vite.config.ts`)
- Dev mode (`npm start`): uses port 3000, fails fast with clear error if taken
- Prod mode (packaged app): scans from 3000 upward, picks first free port

Fixes the port mismatch where Vite proxied to localhost:3000 but Koa was on 3054.

## Test plan
- [ ] `npm start` — UI API calls work (no port mismatch)
- [ ] `npm start` with port 3000 occupied — clear error message
- [ ] Packaged app — still finds free port dynamically