### PR TITLE
docs: testing flow now uses develop as canonical baseline

### DIFF
--- a/docs/testing/contacts-v2.md
+++ b/docs/testing/contacts-v2.md
@@ -15,17 +15,21 @@ What's new vs Phase 1a:
 - Funded Bee node, light mode, at least one usable stamp (only required if you want to publish to the registry — share-link mode works without)
 - For the deep-link test below: nothing extra; it works in browser
 
-## 1. Update your branch
+## 1. Get on `develop`
+
+We integrate every in-flight feature into the `develop` branch so all testers run the same canonical version. Always test from `develop`:
 
 ```bash
 cd <your nook clone>
 git fetch
-git checkout feat/contacts-page
+git checkout develop
 git pull
 cd ui && rm -rf node_modules/.vite && npm install && cd ..
 ```
 
-The `rm -rf node_modules/.vite` is the gotcha that bit us last time — the SHA bump means Vite needs to re-optimize the new SDK on next start, and its cache is otherwise sticky.
+The `rm -rf node_modules/.vite` is the gotcha that's bitten us repeatedly — when the SDK pin changes, Vite needs to re-optimize on next start and its cache is otherwise sticky.
+
+> **Why `develop` and not `feat/contacts-page` directly?** Multiple feature branches in flight can resolve to slightly different SDK pins. `develop` is the single integration point — both testers on `develop` always get the same pin, lockfile, and node_modules. Avoids asymmetric "I can find you but you can't find me" issues that come from version drift.
 
 ## 2. Start Nook
 

--- a/docs/testing/phase-1a-swarm-notify.md
+++ b/docs/testing/phase-1a-swarm-notify.md
@@ -11,18 +11,20 @@ This is a **smoke test before Phase 2**. We're not validating UX or polish here 
 - A funded Bee node (light mode, with at least one usable postage stamp)
 - For step 5 only: ~0.001 xDAI on Gnosis Chain for the on-chain notification
 
-## 1. Get the branch
+## 1. Get on `develop`
+
+All in-flight features are merged into `develop` so testers run the same canonical version:
 
 ```bash
 cd <your nook clone>
 git fetch
-git checkout feat/add-swarm-notify
+git checkout develop
 git pull
 npm install
-cd ui && npm install && cd ..
+cd ui && rm -rf node_modules/.vite && npm install && cd ..
 ```
 
-`ui/package.json` adds `@swarm-notify/sdk` as a git dependency. Install pulls + builds it via the `prepare` script — this can take ~30s the first time.
+`ui/package.json` adds `@swarm-notify/sdk` as a git dependency. Install pulls + builds it via the `prepare` script — this can take ~30s the first time. The Vite cache clear is the gotcha that's bitten us repeatedly when the SDK pin changes.
 
 ### Bee API proxy for Vite dev server
 


### PR DESCRIPTION
After hitting an asymmetric resolution issue caused by two testers being on different feature branches with different SDK pins, the team agreed to integrate everything into a develop branch first.

Both tester docs (contacts-v2.md, phase-1a-swarm-notify.md) now point to develop instead of individual feat/* branches, and include a one-line explanation of why.

No code changes.