### PR TITLE
docs(CLAUDE): document develop / master git flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,40 @@ npm run purge:data     # Clear app data folder
 npm run purge:logs     # Clear app logs folder
 ```
 
+## Git workflow
+
+```
+feature branches  →  develop  →  master
+   (daily work)     (integration)  (releases)
+```
+
+- **`develop`** is the default branch and the canonical baseline for testers. All in-flight features merge here first.
+- **`master`** is for released versions only. Tagged with `vX.Y.Z` after each release.
+- Both branches are protected — every change goes through a PR with the `lint-types-test` CI check.
+
+### Day-to-day
+
+- New feature / fix → branch off `develop`, PR to `develop`
+- Testers always work from `develop` (`git checkout develop && git pull && cd ui && rm -rf node_modules/.vite && npm install && cd ..`). The Vite cache clear is the recurring gotcha when SDK pins change.
+- Things break in `develop`? Fix in another PR to `develop`. `master` stays unaffected.
+
+### Releasing (master gets updated)
+
+1. PR `develop → master` (`gh pr create --base master --head develop`)
+2. CI runs, merge
+3. Bump `package.json` + `ui/package.json` versions, commit "chore: bump version to X.Y.Z" (push to master)
+4. `git tag vX.Y.Z && git push origin vX.Y.Z`
+5. `gh release create vX.Y.Z` with notes (see release section in user memory `MEMORY.md`)
+6. `npm run publish:mac:arm64` to package + `gh release upload` artifacts
+
+### Hotfixes (rare)
+
+Critical bug in production that can't wait for `develop`:
+
+1. Branch `fix/critical-x` off `master`
+2. PR to `master`, merge, tag patch release (e.g., `vX.Y.Z+1`)
+3. **Back-merge `master` into `develop`** so the fix isn't lost on next release: `git checkout develop && git merge master --no-ff`
+
 ## Architecture
 
 The app has two main layers:

--- a/docs/testing/contacts-v2.md
+++ b/docs/testing/contacts-v2.md
@@ -15,17 +15,21 @@ What's new vs Phase 1a:
 - Funded Bee node, light mode, at least one usable stamp (only required if you want to publish to the registry — share-link mode works without)
 - For the deep-link test below: nothing extra; it works in browser
 
-## 1. Update your branch
+## 1. Get on `develop`
+
+We integrate every in-flight feature into the `develop` branch so all testers run the same canonical version. Always test from `develop`:
 
 ```bash
 cd <your nook clone>
 git fetch
-git checkout feat/contacts-page
+git checkout develop
 git pull
 cd ui && rm -rf node_modules/.vite && npm install && cd ..
 ```
 
-The `rm -rf node_modules/.vite` is the gotcha that bit us last time — the SHA bump means Vite needs to re-optimize the new SDK on next start, and its cache is otherwise sticky.
+The `rm -rf node_modules/.vite` is the gotcha that's bitten us repeatedly — when the SDK pin changes, Vite needs to re-optimize on next start and its cache is otherwise sticky.
+
+> **Why `develop` and not `feat/contacts-page` directly?** Multiple feature branches in flight can resolve to slightly different SDK pins. `develop` is the single integration point — both testers on `develop` always get the same pin, lockfile, and node_modules. Avoids asymmetric "I can find you but you can't find me" issues that come from version drift.
 
 ## 2. Start Nook
 

--- a/docs/testing/phase-1a-swarm-notify.md
+++ b/docs/testing/phase-1a-swarm-notify.md
@@ -11,18 +11,20 @@ This is a **smoke test before Phase 2**. We're not validating UX or polish here 
 - A funded Bee node (light mode, with at least one usable postage stamp)
 - For step 5 only: ~0.001 xDAI on Gnosis Chain for the on-chain notification
 
-## 1. Get the branch
+## 1. Get on `develop`
+
+All in-flight features are merged into `develop` so testers run the same canonical version:
 
 ```bash
 cd <your nook clone>
 git fetch
-git checkout feat/add-swarm-notify
+git checkout develop
 git pull
 npm install
-cd ui && npm install && cd ..
+cd ui && rm -rf node_modules/.vite && npm install && cd ..
 ```
 
-`ui/package.json` adds `@swarm-notify/sdk` as a git dependency. Install pulls + builds it via the `prepare` script — this can take ~30s the first time.
+`ui/package.json` adds `@swarm-notify/sdk` as a git dependency. Install pulls + builds it via the `prepare` script — this can take ~30s the first time. The Vite cache clear is the gotcha that's bitten us repeatedly when the SDK pin changes.
 
 ### Bee API proxy for Vite dev server
 


### PR DESCRIPTION
Adds a Git workflow section to CLAUDE.md so contributors and future Claude sessions follow the develop → master flow we agreed on after hitting the SDK-version-mismatch issue between testers.

Covers: day-to-day flow, releases, hotfixes.