### PR TITLE
fix: buffer bee-api proxy req/res + drop CORS headers from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 jobs:
   lint-types-test:

--- a/docs/testing/contacts-v2.md
+++ b/docs/testing/contacts-v2.md
@@ -15,17 +15,21 @@ What's new vs Phase 1a:
 - Funded Bee node, light mode, at least one usable stamp (only required if you want to publish to the registry — share-link mode works without)
 - For the deep-link test below: nothing extra; it works in browser
 
-## 1. Update your branch
+## 1. Get on `develop`
+
+We integrate every in-flight feature into the `develop` branch so all testers run the same canonical version. Always test from `develop`:
 
 ```bash
 cd <your nook clone>
 git fetch
-git checkout feat/contacts-page
+git checkout develop
 git pull
 cd ui && rm -rf node_modules/.vite && npm install && cd ..
 ```
 
-The `rm -rf node_modules/.vite` is the gotcha that bit us last time — the SHA bump means Vite needs to re-optimize the new SDK on next start, and its cache is otherwise sticky.
+The `rm -rf node_modules/.vite` is the gotcha that's bitten us repeatedly — when the SDK pin changes, Vite needs to re-optimize on next start and its cache is otherwise sticky.
+
+> **Why `develop` and not `feat/contacts-page` directly?** Multiple feature branches in flight can resolve to slightly different SDK pins. `develop` is the single integration point — both testers on `develop` always get the same pin, lockfile, and node_modules. Avoids asymmetric "I can find you but you can't find me" issues that come from version drift.
 
 ## 2. Start Nook
 

--- a/docs/testing/phase-1a-swarm-notify.md
+++ b/docs/testing/phase-1a-swarm-notify.md
@@ -11,18 +11,20 @@ This is a **smoke test before Phase 2**. We're not validating UX or polish here 
 - A funded Bee node (light mode, with at least one usable postage stamp)
 - For step 5 only: ~0.001 xDAI on Gnosis Chain for the on-chain notification
 
-## 1. Get the branch
+## 1. Get on `develop`
+
+All in-flight features are merged into `develop` so testers run the same canonical version:
 
 ```bash
 cd <your nook clone>
 git fetch
-git checkout feat/add-swarm-notify
+git checkout develop
 git pull
 npm install
-cd ui && npm install && cd ..
+cd ui && rm -rf node_modules/.vite && npm install && cd ..
 ```
 
-`ui/package.json` adds `@swarm-notify/sdk` as a git dependency. Install pulls + builds it via the `prepare` script — this can take ~30s the first time.
+`ui/package.json` adds `@swarm-notify/sdk` as a git dependency. Install pulls + builds it via the `prepare` script — this can take ~30s the first time. The Vite cache clear is the gotcha that's bitten us repeatedly when the SDK pin changes.
 
 ### Bee API proxy for Vite dev server
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,6 @@ import koaBodyparser from 'koa-bodyparser'
 import mount from 'koa-mount'
 import serve from 'koa-static'
 import * as path from 'path'
-import { Readable } from 'stream'
 
 import { ethers } from 'ethers'
 
@@ -50,28 +49,38 @@ export function runServer() {
     for (const [k, v] of Object.entries(context.headers)) {
       if (typeof v === 'string') headers[k.toLowerCase()] = v
     }
+    // Strip headers Koa / fetch will recompute or that confuse Bee
     delete headers.host
     delete headers['content-length']
+    delete headers.connection
+    delete headers['accept-encoding']
     const hasBody = ['POST', 'PUT', 'PATCH'].includes(context.method)
+    // Buffer the request body — avoids edge cases with streaming + duplex: 'half'
+    let body: Uint8Array | undefined
+
+    if (hasBody) {
+      const chunks: Buffer[] = []
+
+      for await (const chunk of context.req) chunks.push(chunk as Buffer)
+      body = chunks.length > 0 ? new Uint8Array(Buffer.concat(chunks)) : undefined
+    }
 
     try {
-      const res = await fetch(url, {
-        method: context.method,
-        headers,
-        body: hasBody ? (Readable.toWeb(context.req) as ReadableStream) : undefined,
-        // @ts-expect-error duplex: 'half' is required by Node fetch when body is a stream
-        duplex: 'half',
-      })
+      const res = await fetch(url, { method: context.method, headers, body: body as BodyInit | undefined })
 
       context.status = res.status
+      // Forward response headers EXCEPT CORS (Koa CORS middleware adds those —
+      // duplicating causes browsers to fail with "Network Error" even on 2xx)
+      // and EXCEPT transfer encodings Koa will recompute.
       res.headers.forEach((value, key) => {
-        if (key === 'content-length' || key === 'transfer-encoding') return
+        if (key === 'content-length' || key === 'transfer-encoding' || key === 'connection') return
+
+        if (key.startsWith('access-control-')) return
         context.set(key, value)
       })
-
-      if (res.body) {
-        context.body = Readable.fromWeb(res.body as never)
-      }
+      // Buffer response too — Bee API responses are small enough and this
+      // avoids Web Stream / Node Stream conversion issues
+      context.body = Buffer.from(await res.arrayBuffer())
     } catch (e) {
       logger.error(`bee-api proxy failed for ${url}: ${(e as Error).message}`)
       context.status = 502

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,6 +74,7 @@ export function runServer() {
       // and EXCEPT transfer encodings Koa will recompute.
       res.headers.forEach((value, key) => {
         if (key === 'content-length' || key === 'transfer-encoding' || key === 'connection') return
+
         // fetch() auto-decompresses; forwarding content-encoding makes the browser
         // try to decode plain bytes → ERR_CONTENT_DECODING_FAILED
         if (key === 'content-encoding') return

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,6 +74,9 @@ export function runServer() {
       // and EXCEPT transfer encodings Koa will recompute.
       res.headers.forEach((value, key) => {
         if (key === 'content-length' || key === 'transfer-encoding' || key === 'connection') return
+        // fetch() auto-decompresses; forwarding content-encoding makes the browser
+        // try to decode plain bytes → ERR_CONTENT_DECODING_FAILED
+        if (key === 'content-encoding') return
 
         if (key.startsWith('access-control-')) return
         context.set(key, value)


### PR DESCRIPTION
Resolves the 'Network Error' on identity.publish via Koa-served port (3054). Server-side returned 201, but duplicate CORS headers caused the browser to reject the response.

Also buffers bodies in both directions to avoid streaming edge cases that intermittently caused failures with empty / chunked uploads.