### PR TITLE
feat(messages): two-pane chat under Apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nook",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nook",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@ethersphere/bee-js": "^11.1.1",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import Contacts from './pages/Contacts'
 import Dev from './pages/Dev'
 import Drive from './pages/Drive'
 import Settings from './pages/Settings'
+import Messages from './apps/Messages'
 import WebsitePublisher from './apps/WebsitePublisher'
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="settings" element={<Settings />} />
         <Route path="logs" element={<Navigate to="/dev" replace />} />
         <Route path="dev" element={<Dev />} />
+        <Route path="apps/messages" element={<Messages />} />
         <Route path="apps/website-publisher" element={<WebsitePublisher />} />
       </Route>
     </Routes>

--- a/ui/src/apps/Messages.tsx
+++ b/ui/src/apps/Messages.tsx
@@ -1,0 +1,318 @@
+import { Bee } from '@ethersphere/bee-js'
+import { mailbox } from '@swarm-notify/sdk'
+import { Send } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { useStamps } from '../api/queries'
+import { useDerivedKey } from '../hooks/useDerivedKey'
+import { appendSent, loadReadCursors, loadThreads, markRead, mergeReceived, unreadCount } from '../notify/messages'
+import { loadContacts } from '../notify/storage'
+import { toLibraryContact, type NookContact } from '../notify/types'
+
+const BEE_URL = `${window.location.origin}/bee-api`
+const POLL_INTERVAL_MS = 30_000
+
+function short(s: string, n = 6): string {
+  return s.length <= n * 2 + 3 ? s : `${s.slice(0, n)}…${s.slice(-n)}`
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts)
+  const today = new Date()
+  const sameDay = d.toDateString() === today.toDateString()
+
+  return sameDay ? d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : d.toLocaleString()
+}
+
+export default function Messages() {
+  const { signer, derive, walletConnected } = useDerivedKey()
+  const { data: stamps } = useStamps()
+
+  const bee = useMemo(() => new Bee(BEE_URL), [])
+  const contacts = useMemo<NookContact[]>(() => loadContacts(), [])
+
+  const [threads, setThreads] = useState(() => loadThreads())
+  const [cursors, setCursors] = useState(() => loadReadCursors())
+  const [selectedId, setSelectedId] = useState<string | null>(contacts[0]?.id ?? null)
+  const [draft, setDraft] = useState('')
+  const [sending, setSending] = useState(false)
+  const [polling, setPolling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const stampId = (stamps ?? []).find(s => s.usable)?.batchID ?? ''
+  const selected = contacts.find(c => c.id === selectedId) ?? null
+  const selectedThread = selected ? (threads[selected.id.toLowerCase()] ?? []) : []
+
+  const checkInbox = useMemo(
+    () => async () => {
+      if (!signer || contacts.length === 0) return
+      setPolling(true)
+      setError(null)
+      try {
+        const myAddr = signer.getAddress()
+        const inbox = await mailbox.checkInbox(bee, signer.getSigningKey(), myAddr, contacts.map(toLibraryContact))
+
+        setThreads(prev => {
+          let next = prev
+
+          for (const { contact, messages } of inbox) {
+            next = mergeReceived(next, contact.ethAddress, messages)
+          }
+
+          return next
+        })
+      } catch (e) {
+        setError((e as Error).message)
+      } finally {
+        setPolling(false)
+      }
+    },
+    [bee, contacts, signer],
+  )
+
+  // Initial fetch + polling loop
+  useEffect(() => {
+    if (!signer) return
+    void checkInbox()
+    const id = setInterval(() => void checkInbox(), POLL_INTERVAL_MS)
+
+    return () => clearInterval(id)
+  }, [signer, checkInbox])
+
+  // Auto-scroll to bottom on new messages or thread change
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
+  }, [selectedId, selectedThread.length])
+
+  // Mark read when a thread is open and gets new messages
+  useEffect(() => {
+    if (!selected) return
+    const latestTs = selectedThread[selectedThread.length - 1]?.ts
+
+    if (latestTs && latestTs > (cursors[selected.id.toLowerCase()] ?? 0)) {
+      setCursors(prev => markRead(prev, selected.id, latestTs))
+    }
+  }, [selected, selectedThread, cursors])
+
+  async function handleSend() {
+    if (!signer || !selected || !draft.trim()) return
+
+    if (!stampId) {
+      setError('No usable stamp — buy one in Account → My Storage')
+
+      return
+    }
+    setSending(true)
+    setError(null)
+    try {
+      const myAddr = signer.getAddress()
+      const body = draft.trim()
+
+      await mailbox.send(
+        bee,
+        signer.getSigningKey(),
+        stampId,
+        signer.getSigningKey(),
+        myAddr,
+        toLibraryContact(selected),
+        { subject: '', body },
+      )
+      setThreads(prev => appendSent(prev, selected.id, body))
+      setDraft('')
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void handleSend()
+    }
+  }
+
+  if (!walletConnected) {
+    return (
+      <div className="flex flex-col p-6 gap-4 max-w-3xl">
+        <h2 className="text-2xl font-semibold">Messages</h2>
+        <p className="text-sm" style={{ color: 'rgb(var(--fg-muted))' }}>
+          Connect your wallet to see messages.
+        </p>
+      </div>
+    )
+  }
+
+  if (!signer) {
+    return (
+      <div className="flex flex-col p-6 gap-4 max-w-3xl">
+        <h2 className="text-2xl font-semibold">Messages</h2>
+        <p className="text-sm" style={{ color: 'rgb(var(--fg-muted))' }}>
+          Derive your Nook key to start messaging.
+        </p>
+        <button
+          onClick={derive}
+          className="self-start px-4 py-2 rounded text-xs font-semibold uppercase tracking-widest"
+          style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+        >
+          Derive key
+        </button>
+      </div>
+    )
+  }
+
+  if (contacts.length === 0) {
+    return (
+      <div className="flex flex-col p-6 gap-4 max-w-3xl">
+        <h2 className="text-2xl font-semibold">Messages</h2>
+        <p className="text-sm" style={{ color: 'rgb(var(--fg-muted))' }}>
+          You have no contacts yet. Add someone on the Contacts page first.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      {/* Left pane — conversation list */}
+      <div
+        className="w-72 shrink-0 border-r flex flex-col"
+        style={{ borderColor: 'rgb(var(--border))', backgroundColor: 'rgb(var(--bg-surface))' }}
+      >
+        <div
+          className="px-4 py-3 border-b flex items-center justify-between"
+          style={{ borderColor: 'rgb(var(--border))' }}
+        >
+          <h2 className="text-sm font-semibold uppercase tracking-widest" style={{ color: 'rgb(var(--fg-muted))' }}>
+            Conversations
+          </h2>
+          {polling && (
+            <span className="text-[10px]" style={{ color: 'rgb(var(--fg-muted))' }}>
+              syncing…
+            </span>
+          )}
+        </div>
+        <div className="flex-1 overflow-auto">
+          {contacts.map(c => {
+            const thread = threads[c.id.toLowerCase()]
+            const unread = unreadCount(thread, cursors[c.id.toLowerCase()])
+            const last = thread?.[thread.length - 1]
+            const isActive = c.id === selectedId
+
+            return (
+              <button
+                key={c.id}
+                onClick={() => setSelectedId(c.id)}
+                className="w-full text-left px-4 py-3 border-b flex flex-col gap-1 transition-colors"
+                style={{
+                  borderColor: 'rgb(var(--border))',
+                  backgroundColor: isActive ? 'rgba(247,104,8,0.12)' : undefined,
+                }}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium text-sm truncate" style={{ color: 'rgb(var(--fg))' }}>
+                    {c.nickname}
+                  </span>
+                  {unread > 0 && (
+                    <span
+                      className="text-[10px] font-bold px-1.5 py-0.5 rounded-full shrink-0"
+                      style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+                    >
+                      {unread}
+                    </span>
+                  )}
+                </div>
+                <span className="text-xs truncate" style={{ color: 'rgb(var(--fg-muted))' }}>
+                  {last ? `${last.direction === 'sent' ? 'You: ' : ''}${last.body}` : short(c.id)}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Right pane — selected thread + compose */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {selected ? (
+          <>
+            <div className="px-6 py-3 border-b" style={{ borderColor: 'rgb(var(--border))' }}>
+              <h2 className="text-base font-semibold" style={{ color: 'rgb(var(--fg))' }}>
+                {selected.nickname}
+              </h2>
+              <p className="text-xs font-mono" style={{ color: 'rgb(var(--fg-muted))' }}>
+                {short(selected.id, 8)}
+              </p>
+            </div>
+            <div ref={scrollRef} className="flex-1 overflow-auto px-6 py-4 flex flex-col gap-3">
+              {selectedThread.length === 0 ? (
+                <p className="text-sm m-auto" style={{ color: 'rgb(var(--fg-muted))' }}>
+                  No messages yet. Say hello.
+                </p>
+              ) : (
+                selectedThread.map(m => (
+                  <div
+                    key={m.id}
+                    className={`max-w-[70%] rounded-2xl px-4 py-2 ${m.direction === 'sent' ? 'self-end' : 'self-start'}`}
+                    style={{
+                      backgroundColor: m.direction === 'sent' ? 'rgb(var(--accent))' : 'rgb(var(--bg-surface))',
+                      color: m.direction === 'sent' ? '#fff' : 'rgb(var(--fg))',
+                    }}
+                  >
+                    <p className="text-sm whitespace-pre-wrap break-words">{m.body}</p>
+                    <p
+                      className="text-[10px] mt-1"
+                      style={{ color: m.direction === 'sent' ? 'rgba(255,255,255,0.7)' : 'rgb(var(--fg-muted))' }}
+                    >
+                      {formatTime(m.ts)}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="border-t p-4" style={{ borderColor: 'rgb(var(--border))' }}>
+              {error && (
+                <p className="text-xs mb-2" style={{ color: '#ef4444' }}>
+                  {error}
+                </p>
+              )}
+              <div className="flex gap-2 items-end">
+                <textarea
+                  value={draft}
+                  onChange={e => setDraft(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder={`Message ${selected.nickname}…`}
+                  rows={1}
+                  className="flex-1 rounded-lg border px-3 py-2 text-sm resize-none focus:outline-none"
+                  style={{
+                    backgroundColor: 'rgb(var(--bg))',
+                    color: 'rgb(var(--fg))',
+                    borderColor: 'rgb(var(--border))',
+                    minHeight: 40,
+                    maxHeight: 160,
+                  }}
+                />
+                <button
+                  onClick={handleSend}
+                  disabled={sending || !draft.trim()}
+                  className="rounded-lg p-2.5 transition-opacity disabled:opacity-40"
+                  style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+                  title="Send (Enter)"
+                >
+                  <Send size={16} />
+                </button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-sm" style={{ color: 'rgb(var(--fg-muted))' }}>
+              Select a conversation
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import {
   Globe,
   HardDrive,
   LogOut,
+  MessageSquare,
   RefreshCw,
   Settings,
   Terminal,
@@ -29,7 +30,10 @@ const mainNavItems = [
 
 const settingsNavItem = { to: '/settings', icon: Settings, label: 'Settings' }
 
-const appNavItems = [{ to: '/apps/website-publisher', icon: Globe, label: 'Publish', sublabel: 'website' }]
+const appNavItems = [
+  { to: '/apps/messages', icon: MessageSquare, label: 'Messages', sublabel: '' },
+  { to: '/apps/website-publisher', icon: Globe, label: 'Publish', sublabel: 'website' },
+]
 
 function WalletDropdown({ displayName, address, avatar }: { displayName: string; address: string; avatar?: string }) {
   const [open, setOpen] = useState(false)
@@ -122,6 +126,7 @@ export default function Layout() {
     '/contacts': 'Contacts',
     '/settings': 'Settings',
     '/dev': 'Dev mode',
+    '/apps/messages': 'Messages',
     '/apps/website-publisher': 'Publish website',
   }
   const pageTitle = pageTitles[location.pathname] ?? ''
@@ -242,8 +247,12 @@ export default function Layout() {
               <Icon size={15} />
               <span className="text-[9px] font-medium leading-tight text-center">
                 {label}
-                <br />
-                {sublabel}
+                {sublabel && (
+                  <>
+                    <br />
+                    {sublabel}
+                  </>
+                )}
               </span>
             </NavLink>
           ))}

--- a/ui/src/notify/messages.ts
+++ b/ui/src/notify/messages.ts
@@ -1,0 +1,111 @@
+import type { Message as SdkMessage } from '@swarm-notify/sdk'
+
+/**
+ * Local persistence for message threads.
+ *
+ * The swarm-notify SDK reads received messages from each contact's outgoing
+ * feed (contact→me). It does not store sent messages anywhere readable, so we
+ * keep our own copy in localStorage. On every inbox poll we refresh the
+ * `received` slice per contact; `sent` messages stay local until the SDK gains
+ * a "read my own outbox" call.
+ *
+ * Per-origin like `nook-contacts-v2`. Tracked at #47.
+ */
+
+export interface StoredMessage {
+  /** Stable id — `${ts}-${direction}-${shortBody}` for dedupe */
+  id: string
+  /** Counterparty (the OTHER party) — lowercased ETH address */
+  counterparty: string
+  /** Unix ms */
+  ts: number
+  /** Plain text */
+  body: string
+  direction: 'sent' | 'received'
+}
+
+const MESSAGES_KEY = 'nook-messages-v1'
+const READ_CURSOR_KEY = 'nook-messages-read-v1'
+
+type ThreadMap = Record<string, StoredMessage[]>
+type ReadCursorMap = Record<string, number>
+
+function load<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+
+    return raw ? (JSON.parse(raw) as T) : fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function loadThreads(): ThreadMap {
+  return load<ThreadMap>(MESSAGES_KEY, {})
+}
+
+export function saveThreads(threads: ThreadMap): void {
+  localStorage.setItem(MESSAGES_KEY, JSON.stringify(threads))
+}
+
+export function loadReadCursors(): ReadCursorMap {
+  return load<ReadCursorMap>(READ_CURSOR_KEY, {})
+}
+
+export function saveReadCursors(cursors: ReadCursorMap): void {
+  localStorage.setItem(READ_CURSOR_KEY, JSON.stringify(cursors))
+}
+
+function makeId(ts: number, direction: StoredMessage['direction'], body: string): string {
+  return `${ts}-${direction}-${body.slice(0, 32)}`
+}
+
+/** Append a sent message to a thread. */
+export function appendSent(threads: ThreadMap, counterparty: string, body: string, ts = Date.now()): ThreadMap {
+  const key = counterparty.toLowerCase()
+  const msg: StoredMessage = { id: makeId(ts, 'sent', body), counterparty: key, ts, body, direction: 'sent' }
+  const updated: ThreadMap = { ...threads, [key]: [...(threads[key] ?? []), msg] }
+
+  saveThreads(updated)
+
+  return updated
+}
+
+/**
+ * Replace the `received` slice for a counterparty with fresh data from the SDK.
+ * Sent messages are preserved.
+ */
+export function mergeReceived(threads: ThreadMap, counterparty: string, received: SdkMessage[]): ThreadMap {
+  const key = counterparty.toLowerCase()
+  const existingSent = (threads[key] ?? []).filter(m => m.direction === 'sent')
+  const incoming: StoredMessage[] = received.map(m => ({
+    id: makeId(m.ts, 'received', m.body),
+    counterparty: key,
+    ts: m.ts,
+    body: m.body,
+    direction: 'received',
+  }))
+  const merged = [...existingSent, ...incoming].sort((a, b) => a.ts - b.ts)
+  const updated: ThreadMap = { ...threads, [key]: merged }
+
+  saveThreads(updated)
+
+  return updated
+}
+
+/** Count unread received messages for a counterparty. */
+export function unreadCount(thread: StoredMessage[] | undefined, cursor: number | undefined): number {
+  if (!thread) return 0
+  const c = cursor ?? 0
+
+  return thread.filter(m => m.direction === 'received' && m.ts > c).length
+}
+
+/** Mark a conversation read up to `ts` (defaults to now). */
+export function markRead(cursors: ReadCursorMap, counterparty: string, ts = Date.now()): ReadCursorMap {
+  const updated = { ...cursors, [counterparty.toLowerCase()]: ts }
+
+  saveReadCursors(updated)
+
+  return updated
+}


### PR DESCRIPTION
## Summary

New **Messages** app under the sidebar APPS section. Two-pane chat that reuses the existing `nook-contacts-v2` store so both registry- and share-link-added contacts are messageable.

## Behaviour

- Sidebar entry between *Drive/Account/Contacts* group and *Publish website*
- Left pane: conversation list with last-message preview + unread badge
- Right pane: thread + compose box (Enter to send, Shift+Enter for newline)
- No subject field in the UI — SDK still requires one in the payload, sent as `''`
- Inbox polls every 30s; first fetch on mount
- Threads + read cursors persisted in localStorage (`nook-messages-v1`, `nook-messages-read-v1`) so sent messages survive reload (the SDK only reads contact→me feeds)

## How to test (with Crt)

1. `git checkout feat/messages-page && npm install && cd ui && npm install && cd ..`
2. Both: `npm start`, derive key, make sure the other person is in your Contacts (registry or share-link, either works)
3. Click **Messages** in the sidebar (under APPS)
4. Click the contact in the left pane → type → Enter
5. Other side: open Messages → wait up to 30s for poll, or reload — new message should appear

## Known polish items (out of scope, can land later)

- Right pane has lots of empty space at wide viewports
- Sent-bubble timestamp clips at the right edge in narrow viewports
- "Conversations" header duplicates the route title slightly
- No manual refresh button — only the 30s poll