### PR TITLE
feat: drive share with contact + on-chain notifications, end-to-end

### DIFF
--- a/ui/src/apps/Messages.tsx
+++ b/ui/src/apps/Messages.tsx
@@ -1,14 +1,15 @@
 import { Bee } from '@ethersphere/bee-js'
-import { mailbox } from '@swarm-notify/sdk'
-import { FileText, Send } from 'lucide-react'
+import { identity, mailbox } from '@swarm-notify/sdk'
+import { FileText, Mail, Send } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useStamps } from '../api/queries'
 import AddSharedDriveModal from '../components/AddSharedDriveModal'
 import { useSharedDrives } from '../hooks/useSharedDrives'
 import { useDerivedKey } from '../hooks/useDerivedKey'
+import { loadInvitations, markInvitationProcessed, pendingInvitations, type Invitation } from '../notify/invitations'
 import { appendSent, loadReadCursors, loadThreads, markRead, unreadCount } from '../notify/messages'
-import { loadContacts } from '../notify/storage'
+import { addContact, loadContacts } from '../notify/storage'
 import { toLibraryContact, type NookContact } from '../notify/types'
 
 const BEE_URL = `${window.location.origin}/bee-api`
@@ -30,7 +31,10 @@ export default function Messages() {
   const { data: stamps } = useStamps()
 
   const bee = useMemo(() => new Bee(BEE_URL), [])
-  const contacts = useMemo<NookContact[]>(() => loadContacts(), [])
+  // Re-read each render cycle so newly-added contacts (eg via accepting an
+  // invitation) appear without a remount.
+  const [contacts, setContacts] = useState<NookContact[]>(() => loadContacts())
+  const [invitations, setInvitations] = useState<Invitation[]>(() => loadInvitations())
 
   const [threads, setThreads] = useState(() => loadThreads())
   const [cursors, setCursors] = useState(() => loadReadCursors())
@@ -40,18 +44,63 @@ export default function Messages() {
   const [error, setError] = useState<string | null>(null)
   // Pre-filled share link when the user clicks "Add drive" on a drive-share card
   const [importingLink, setImportingLink] = useState<string | null>(null)
+  // Invitation acceptance state — nickname input + in-flight flag
+  const [inviteNickname, setInviteNickname] = useState('')
+  const [acceptingInvite, setAcceptingInvite] = useState(false)
   const sharedDrives = useSharedDrives()
   const scrollRef = useRef<HTMLDivElement>(null)
+
+  const pending = useMemo(() => pendingInvitations(invitations), [invitations])
 
   const stampId = (stamps ?? []).find(s => s.usable)?.batchID ?? ''
   const selected = contacts.find(c => c.id === selectedId) ?? null
   const selectedThread = selected ? (threads[selected.id.toLowerCase()] ?? []) : []
+  // If the selected entry isn't a contact, it might be a pending invitation.
+  const selectedInvite = !selected ? (pending.find(i => i.senderAddr === selectedId?.toLowerCase()) ?? null) : null
 
-  // Inbox polling now lives at the Layout level (useInboxPolling) so messages
-  // arrive even when this page isn't mounted. We just re-read localStorage on
-  // a short interval to pick up Layout's writes and reflect new messages here.
+  async function handleAcceptInvite() {
+    if (!selectedInvite || !inviteNickname.trim()) return
+    setAcceptingInvite(true)
+    setError(null)
+    try {
+      // Resolve sender's identity via their feed to get wpub + bpub
+      const resolved = await identity.resolve(bee, selectedInvite.senderAddr)
+
+      if (!resolved) {
+        setError('Could not resolve sender identity. They may have unpublished.')
+
+        return
+      }
+
+      const next = addContact(contacts, {
+        id: selectedInvite.senderAddr,
+        nickname: inviteNickname.trim(),
+        walletPublicKey: resolved.walletPublicKey,
+        beePublicKey: resolved.beePublicKey,
+        source: 'identity-feed',
+        addedAt: Date.now(),
+      })
+
+      setContacts(next)
+      setInvitations(prev => markInvitationProcessed(prev, selectedInvite.senderAddr))
+      setSelectedId(selectedInvite.senderAddr) // switch into the new conversation
+      setInviteNickname('')
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to add contact')
+    } finally {
+      setAcceptingInvite(false)
+    }
+  }
+
+  // Inbox + invitation polling lives at the Layout level. We just re-read
+  // localStorage on a short interval to pick up writes (new messages,
+  // contacts added in another tab, on-chain invitations).
   useEffect(() => {
-    const id = setInterval(() => setThreads(loadThreads()), 3_000)
+    const id = setInterval(() => {
+      setThreads(loadThreads())
+      setContacts(loadContacts())
+      setInvitations(loadInvitations())
+    }, 3_000)
 
     return () => clearInterval(id)
   }, [])
@@ -139,7 +188,7 @@ export default function Messages() {
     )
   }
 
-  if (contacts.length === 0) {
+  if (contacts.length === 0 && pending.length === 0) {
     return (
       <div className="flex flex-col p-6 gap-4 max-w-3xl">
         <h2 className="text-2xl font-semibold">Messages</h2>
@@ -166,6 +215,35 @@ export default function Messages() {
           </h2>
         </div>
         <div className="flex-1 overflow-auto">
+          {/* Pending invitations — on-chain pings from senders not yet in contacts */}
+          {pending.map(inv => {
+            const isActive = inv.senderAddr === selectedId?.toLowerCase()
+
+            return (
+              <button
+                key={inv.senderAddr}
+                onClick={() => {
+                  setSelectedId(inv.senderAddr)
+                  setInviteNickname('')
+                }}
+                className="w-full text-left px-4 py-3 border-b flex flex-col gap-1 transition-colors"
+                style={{
+                  borderColor: 'rgb(var(--border))',
+                  backgroundColor: isActive ? 'rgba(247,104,8,0.12)' : 'rgba(96,165,250,0.06)',
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <Mail size={12} style={{ color: '#60a5fa' }} />
+                  <span className="font-medium text-sm truncate font-mono" style={{ color: 'rgb(var(--fg))' }}>
+                    {short(inv.senderAddr, 8)}
+                  </span>
+                </div>
+                <span className="text-xs truncate" style={{ color: 'rgb(var(--fg-muted))' }}>
+                  Wants to reach you
+                </span>
+              </button>
+            )
+          })}
           {contacts.map(c => {
             const thread = threads[c.id.toLowerCase()]
             const unread = unreadCount(thread, cursors[c.id.toLowerCase()])
@@ -319,6 +397,58 @@ export default function Messages() {
               </div>
             </div>
           </>
+        ) : selectedInvite ? (
+          <div className="flex-1 flex flex-col p-6 gap-4 max-w-xl">
+            <div className="flex items-center gap-2">
+              <Mail size={18} style={{ color: '#60a5fa' }} />
+              <h2 className="text-base font-semibold" style={{ color: 'rgb(var(--fg))' }}>
+                Someone wants to reach you
+              </h2>
+            </div>
+            <div
+              className="rounded-lg border p-4 space-y-2"
+              style={{ backgroundColor: 'rgb(var(--bg-surface))', borderColor: 'rgb(var(--border))' }}
+            >
+              <p className="text-xs font-mono break-all" style={{ color: 'rgb(var(--fg-muted))' }}>
+                {selectedInvite.senderAddr}
+              </p>
+              <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
+                They sent you an on-chain wake-up at block {selectedInvite.blockNumber}. Add them as a contact to see
+                any messages or drive shares they&apos;ve sent.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-widest" style={{ color: 'rgb(var(--fg-muted))' }}>
+                Nickname
+              </label>
+              <input
+                type="text"
+                value={inviteNickname}
+                onChange={e => setInviteNickname(e.target.value)}
+                placeholder="e.g. Alice"
+                className="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none"
+                style={{
+                  backgroundColor: 'rgb(var(--bg))',
+                  color: 'rgb(var(--fg))',
+                  borderColor: 'rgb(var(--border))',
+                }}
+                autoFocus
+              />
+            </div>
+            {error && (
+              <p className="text-xs" style={{ color: '#ef4444' }}>
+                {error}
+              </p>
+            )}
+            <button
+              onClick={handleAcceptInvite}
+              disabled={acceptingInvite || !inviteNickname.trim()}
+              className="self-start px-4 py-2 rounded-lg text-sm font-semibold disabled:opacity-40"
+              style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+            >
+              {acceptingInvite ? 'Resolving & adding…' : 'Add as contact'}
+            </button>
+          </div>
         ) : (
           <div className="flex-1 flex items-center justify-center">
             <p className="text-sm" style={{ color: 'rgb(var(--fg-muted))' }}>

--- a/ui/src/apps/Messages.tsx
+++ b/ui/src/apps/Messages.tsx
@@ -1,9 +1,11 @@
 import { Bee } from '@ethersphere/bee-js'
 import { mailbox } from '@swarm-notify/sdk'
-import { Send } from 'lucide-react'
+import { FileText, Send } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useStamps } from '../api/queries'
+import AddSharedDriveModal from '../components/AddSharedDriveModal'
+import { useSharedDrives } from '../hooks/useSharedDrives'
 import { useDerivedKey } from '../hooks/useDerivedKey'
 import { appendSent, loadReadCursors, loadThreads, markRead, mergeReceived, unreadCount } from '../notify/messages'
 import { loadContacts } from '../notify/storage'
@@ -38,6 +40,9 @@ export default function Messages() {
   const [sending, setSending] = useState(false)
   const [polling, setPolling] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Pre-filled share link when the user clicks "Add drive" on a drive-share card
+  const [importingLink, setImportingLink] = useState<string | null>(null)
+  const sharedDrives = useSharedDrives()
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const stampId = (stamps ?? []).find(s => s.usable)?.batchID ?? ''
@@ -251,24 +256,67 @@ export default function Messages() {
                   No messages yet. Say hello.
                 </p>
               ) : (
-                selectedThread.map(m => (
-                  <div
-                    key={m.id}
-                    className={`max-w-[70%] rounded-2xl px-4 py-2 ${m.direction === 'sent' ? 'self-end' : 'self-start'}`}
-                    style={{
-                      backgroundColor: m.direction === 'sent' ? 'rgb(var(--accent))' : 'rgb(var(--bg-surface))',
-                      color: m.direction === 'sent' ? '#fff' : 'rgb(var(--fg))',
-                    }}
-                  >
-                    <p className="text-sm whitespace-pre-wrap break-words">{m.body}</p>
-                    <p
-                      className="text-[10px] mt-1"
-                      style={{ color: m.direction === 'sent' ? 'rgba(255,255,255,0.7)' : 'rgb(var(--fg-muted))' }}
+                selectedThread.map(m => {
+                  if (m.kind === 'drive-share' && m.driveShareLink) {
+                    const isSent = m.direction === 'sent'
+
+                    return (
+                      <div
+                        key={m.id}
+                        className={`max-w-[80%] rounded-2xl border px-4 py-3 space-y-2 ${isSent ? 'self-end' : 'self-start'}`}
+                        style={{
+                          backgroundColor: 'rgb(var(--bg-surface))',
+                          borderColor: 'rgb(var(--accent))',
+                          color: 'rgb(var(--fg))',
+                        }}
+                      >
+                        <div className="flex items-center gap-2">
+                          <FileText size={14} style={{ color: 'rgb(var(--accent))' }} />
+                          <span className="text-xs uppercase tracking-widest" style={{ color: 'rgb(var(--accent))' }}>
+                            {isSent ? 'Drive shared' : 'Drive shared with you'}
+                          </span>
+                        </div>
+                        <div>
+                          <p className="text-sm font-semibold">{m.driveName ?? 'Encrypted drive'}</p>
+                          <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
+                            {m.fileCount ?? 0} file{m.fileCount === 1 ? '' : 's'}
+                          </p>
+                        </div>
+                        {!isSent && (
+                          <button
+                            onClick={() => setImportingLink(m.driveShareLink!)}
+                            className="w-full py-1.5 rounded-lg text-xs font-semibold"
+                            style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+                          >
+                            Add drive
+                          </button>
+                        )}
+                        <p className="text-[10px]" style={{ color: 'rgb(var(--fg-muted))' }}>
+                          {formatTime(m.ts)}
+                        </p>
+                      </div>
+                    )
+                  }
+
+                  return (
+                    <div
+                      key={m.id}
+                      className={`max-w-[70%] rounded-2xl px-4 py-2 ${m.direction === 'sent' ? 'self-end' : 'self-start'}`}
+                      style={{
+                        backgroundColor: m.direction === 'sent' ? 'rgb(var(--accent))' : 'rgb(var(--bg-surface))',
+                        color: m.direction === 'sent' ? '#fff' : 'rgb(var(--fg))',
+                      }}
                     >
-                      {formatTime(m.ts)}
-                    </p>
-                  </div>
-                ))
+                      <p className="text-sm whitespace-pre-wrap break-words">{m.body}</p>
+                      <p
+                        className="text-[10px] mt-1"
+                        style={{ color: m.direction === 'sent' ? 'rgba(255,255,255,0.7)' : 'rgb(var(--fg-muted))' }}
+                      >
+                        {formatTime(m.ts)}
+                      </p>
+                    </div>
+                  )
+                })
               )}
             </div>
             <div className="border-t p-4" style={{ borderColor: 'rgb(var(--border))' }}>
@@ -313,6 +361,14 @@ export default function Messages() {
           </div>
         )}
       </div>
+
+      {importingLink && (
+        <AddSharedDriveModal
+          initialLink={importingLink}
+          onClose={() => setImportingLink(null)}
+          onAdd={drive => sharedDrives.add(drive)}
+        />
+      )}
     </div>
   )
 }

--- a/ui/src/apps/Messages.tsx
+++ b/ui/src/apps/Messages.tsx
@@ -47,6 +47,17 @@ export default function Messages() {
   // Invitation acceptance state — nickname input + in-flight flag
   const [inviteNickname, setInviteNickname] = useState('')
   const [acceptingInvite, setAcceptingInvite] = useState(false)
+  // Pre-acceptance peek: read sender's identity feed + mailbox so the
+  // invitation panel can show context (sender name, their first message)
+  // before the recipient commits to adding the contact.
+  type InvitePreview = {
+    loading: boolean
+    senderName?: string
+    firstSubject?: string
+    firstBody?: string
+    error?: string
+  }
+  const [invitePreview, setInvitePreview] = useState<InvitePreview>({ loading: false })
   const sharedDrives = useSharedDrives()
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -91,6 +102,70 @@ export default function Messages() {
       setAcceptingInvite(false)
     }
   }
+
+  // When user selects a pending invitation, peek the sender's mailbox feed.
+  // Read-only: no contact saved yet. Tries to extract a friendly name from
+  // the message subject pattern emitted by ShareModal: "Name shared "X" with you".
+  useEffect(() => {
+    if (!selectedInvite || !signer) {
+      setInvitePreview({ loading: false })
+
+      return
+    }
+    let cancelled = false
+
+    setInvitePreview({ loading: true })
+    const myAddr = signer.getAddress()
+    const senderAddr = selectedInvite.senderAddr
+
+    ;(async () => {
+      try {
+        const resolved = await identity.resolve(bee, senderAddr)
+
+        if (cancelled) return
+
+        if (!resolved) {
+          setInvitePreview({ loading: false, error: 'Sender identity not published.' })
+
+          return
+        }
+        // Construct a temp Contact for the read — never persisted.
+        const tempContact = {
+          ethAddress: senderAddr,
+          nickname: '',
+          walletPublicKey: resolved.walletPublicKey,
+          beePublicKey: resolved.beePublicKey,
+          addedAt: Date.now(),
+        }
+        const messages = await mailbox.readMessages(bee, signer.getSigningKey(), myAddr, tempContact)
+
+        if (cancelled) return
+        const first = messages[messages.length - 1] ?? messages[0]
+        // Extract sender name from "Name shared "X" with you" pattern.
+        const match = first?.subject?.match(/^(.+?)\s+shared\s+"/)
+        const extractedName = match?.[1]?.trim()
+
+        setInvitePreview({
+          loading: false,
+          senderName: extractedName,
+          firstSubject: first?.subject,
+          firstBody: first?.body,
+        })
+
+        // Pre-fill nickname suggestion if we have one and the user hasn't typed.
+        if (extractedName && !inviteNickname) setInviteNickname(extractedName)
+      } catch (e) {
+        if (cancelled) return
+        setInvitePreview({ loading: false, error: (e as Error).message ?? 'Could not preview' })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+    // inviteNickname intentionally omitted — only auto-fill once on first load
+    // eslint-disable-next-line
+  }, [selectedInvite, signer, bee])
 
   // Inbox + invitation polling lives at the Layout level. We just re-read
   // localStorage on a short interval to pick up writes (new messages,
@@ -402,7 +477,9 @@ export default function Messages() {
             <div className="flex items-center gap-2">
               <Mail size={18} style={{ color: '#60a5fa' }} />
               <h2 className="text-base font-semibold" style={{ color: 'rgb(var(--fg))' }}>
-                Someone wants to reach you
+                {invitePreview.senderName
+                  ? `${invitePreview.senderName} wants to reach you`
+                  : 'Someone wants to reach you'}
               </h2>
             </div>
             <div
@@ -412,10 +489,35 @@ export default function Messages() {
               <p className="text-xs font-mono break-all" style={{ color: 'rgb(var(--fg-muted))' }}>
                 {selectedInvite.senderAddr}
               </p>
-              <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
-                They sent you an on-chain wake-up at block {selectedInvite.blockNumber}. Add them as a contact to see
-                any messages or drive shares they&apos;ve sent.
-              </p>
+              {invitePreview.loading && (
+                <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
+                  Reading sender&apos;s mailbox feed…
+                </p>
+              )}
+              {invitePreview.firstSubject && (
+                <div className="rounded border-l-2 pl-3 py-1 mt-2" style={{ borderColor: 'rgb(var(--accent))' }}>
+                  <p className="text-sm font-medium" style={{ color: 'rgb(var(--fg))' }}>
+                    {invitePreview.firstSubject}
+                  </p>
+                  {invitePreview.firstBody && (
+                    <p className="text-xs mt-1" style={{ color: 'rgb(var(--fg-muted))' }}>
+                      {invitePreview.firstBody}
+                    </p>
+                  )}
+                </div>
+              )}
+              {invitePreview.error && (
+                <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
+                  Couldn&apos;t peek the sender&apos;s feed yet ({invitePreview.error}). Add them as a contact to see
+                  the message.
+                </p>
+              )}
+              {!invitePreview.loading && !invitePreview.firstSubject && !invitePreview.error && (
+                <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
+                  They sent you an on-chain wake-up at block {selectedInvite.blockNumber}. Add them as a contact to see
+                  any messages or drive shares they&apos;ve sent.
+                </p>
+              )}
             </div>
             <div className="space-y-2">
               <label className="text-xs uppercase tracking-widest" style={{ color: 'rgb(var(--fg-muted))' }}>

--- a/ui/src/apps/Messages.tsx
+++ b/ui/src/apps/Messages.tsx
@@ -7,12 +7,11 @@ import { useStamps } from '../api/queries'
 import AddSharedDriveModal from '../components/AddSharedDriveModal'
 import { useSharedDrives } from '../hooks/useSharedDrives'
 import { useDerivedKey } from '../hooks/useDerivedKey'
-import { appendSent, loadReadCursors, loadThreads, markRead, mergeReceived, unreadCount } from '../notify/messages'
+import { appendSent, loadReadCursors, loadThreads, markRead, unreadCount } from '../notify/messages'
 import { loadContacts } from '../notify/storage'
 import { toLibraryContact, type NookContact } from '../notify/types'
 
 const BEE_URL = `${window.location.origin}/bee-api`
-const POLL_INTERVAL_MS = 30_000
 
 function short(s: string, n = 6): string {
   return s.length <= n * 2 + 3 ? s : `${s.slice(0, n)}…${s.slice(-n)}`
@@ -38,7 +37,6 @@ export default function Messages() {
   const [selectedId, setSelectedId] = useState<string | null>(contacts[0]?.id ?? null)
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
-  const [polling, setPolling] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Pre-filled share link when the user clicks "Add drive" on a drive-share card
   const [importingLink, setImportingLink] = useState<string | null>(null)
@@ -49,41 +47,14 @@ export default function Messages() {
   const selected = contacts.find(c => c.id === selectedId) ?? null
   const selectedThread = selected ? (threads[selected.id.toLowerCase()] ?? []) : []
 
-  const checkInbox = useMemo(
-    () => async () => {
-      if (!signer || contacts.length === 0) return
-      setPolling(true)
-      setError(null)
-      try {
-        const myAddr = signer.getAddress()
-        const inbox = await mailbox.checkInbox(bee, signer.getSigningKey(), myAddr, contacts.map(toLibraryContact))
-
-        setThreads(prev => {
-          let next = prev
-
-          for (const { contact, messages } of inbox) {
-            next = mergeReceived(next, contact.ethAddress, messages)
-          }
-
-          return next
-        })
-      } catch (e) {
-        setError((e as Error).message)
-      } finally {
-        setPolling(false)
-      }
-    },
-    [bee, contacts, signer],
-  )
-
-  // Initial fetch + polling loop
+  // Inbox polling now lives at the Layout level (useInboxPolling) so messages
+  // arrive even when this page isn't mounted. We just re-read localStorage on
+  // a short interval to pick up Layout's writes and reflect new messages here.
   useEffect(() => {
-    if (!signer) return
-    void checkInbox()
-    const id = setInterval(() => void checkInbox(), POLL_INTERVAL_MS)
+    const id = setInterval(() => setThreads(loadThreads()), 3_000)
 
     return () => clearInterval(id)
-  }, [signer, checkInbox])
+  }, [])
 
   // Auto-scroll to bottom on new messages or thread change
   useEffect(() => {
@@ -193,11 +164,6 @@ export default function Messages() {
           <h2 className="text-sm font-semibold uppercase tracking-widest" style={{ color: 'rgb(var(--fg-muted))' }}>
             Conversations
           </h2>
-          {polling && (
-            <span className="text-[10px]" style={{ color: 'rgb(var(--fg-muted))' }}>
-              syncing…
-            </span>
-          )}
         </div>
         <div className="flex-1 overflow-auto">
           {contacts.map(c => {

--- a/ui/src/components/AddSharedDriveModal.tsx
+++ b/ui/src/components/AddSharedDriveModal.tsx
@@ -14,6 +14,8 @@ import type { NookContact } from '../notify/types'
 
 interface AddSharedDriveModalProps {
   myPublicKey?: string
+  /** Pre-fill the share-link textarea (e.g. when opened from a Messages drive-share card) */
+  initialLink?: string
   onClose: () => void
   onAdd: (drive: {
     name: string
@@ -26,8 +28,8 @@ interface AddSharedDriveModalProps {
   }) => void
 }
 
-export default function AddSharedDriveModal({ myPublicKey, onClose, onAdd }: AddSharedDriveModalProps) {
-  const [link, setLink] = useState('')
+export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose, onAdd }: AddSharedDriveModalProps) {
+  const [link, setLink] = useState(initialLink ?? '')
   const [name, setName] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/ui/src/components/AddSharedDriveModal.tsx
+++ b/ui/src/components/AddSharedDriveModal.tsx
@@ -1,14 +1,16 @@
 /**
- * AddSharedDriveModal — paste a share link to add a drive shared by someone else.
- * Supports both feed-based (live) and snapshot (legacy) share links.
+ * AddSharedDriveModal — paste a `nook://drive-share` link to add a drive shared
+ * by someone else. If the link bundles the sender's contact info, offer to add
+ * them as a contact in the same step.
  */
 import { Check, Copy, Download, RefreshCw, X } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { beeApi } from '../api/bee'
 import { serverApi } from '../api/server'
-import { parseShareLink } from '../hooks/useSharedDrives'
-import type { SharedFile } from '../hooks/useSharedDrives'
+import { parseShareLink, type SenderContactInfo, type SharedFile } from '../hooks/useSharedDrives'
+import { addContact, loadContacts } from '../notify/storage'
+import type { NookContact } from '../notify/types'
 
 interface AddSharedDriveModalProps {
   myPublicKey?: string
@@ -31,11 +33,34 @@ export default function AddSharedDriveModal({ myPublicKey, onClose, onAdd }: Add
   const [error, setError] = useState<string | null>(null)
   const [copiedKey, setCopiedKey] = useState(false)
 
-  async function handleAdd() {
-    const parsed = parseShareLink(link)
+  // Sender contact import
+  const existingContacts = useMemo<NookContact[]>(() => loadContacts(), [])
+  const [addAsContact, setAddAsContact] = useState(true)
+  const [contactNickname, setContactNickname] = useState('')
 
+  const parsed = useMemo(() => (link.trim() ? parseShareLink(link) : null), [link])
+  const sender: SenderContactInfo | undefined = parsed?.sender
+  const senderAlreadyContact = useMemo(() => {
+    if (!sender) return false
+
+    return existingContacts.some(c => c.id.toLowerCase() === sender.addr.toLowerCase())
+  }, [sender, existingContacts])
+  const showContactImport = Boolean(sender) && !senderAlreadyContact
+
+  // Pre-fill nickname from sender's bundled name (or empty if absent)
+  useEffect(() => {
+    if (sender && !contactNickname) setContactNickname(sender.name ?? '')
+  }, [sender, contactNickname])
+
+  async function handleAdd() {
     if (!parsed) {
       setError('Invalid share link.')
+
+      return
+    }
+
+    if (showContactImport && addAsContact && !contactNickname.trim()) {
+      setError('Type a nickname for the new contact, or uncheck "Add as contact".')
 
       return
     }
@@ -44,53 +69,44 @@ export default function AddSharedDriveModal({ myPublicKey, onClose, onAdd }: Add
     setError(null)
 
     try {
-      let driveName = name.trim() || 'Shared drive'
-      let files: SharedFile[] | undefined
-      let reference = ''
-      let actHistoryRef = ''
+      // Drive: read feed → get wrapper → ACT download metadata
+      const wrapperText = await serverApi.readFeed(parsed.feedTopic, parsed.feedOwner)
+      const wrapper = JSON.parse(wrapperText) as { ref: string; history: string }
 
-      if (parsed.type === 'feed' && parsed.feedTopic && parsed.feedOwner) {
-        // Feed-based: read feed → get wrapper → ACT download metadata
-        const wrapperText = await serverApi.readFeed(parsed.feedTopic, parsed.feedOwner)
-        const wrapper = JSON.parse(wrapperText) as { ref: string; history: string }
+      const blob = await beeApi.downloadFileWithACT(wrapper.ref, parsed.actPublisher, wrapper.history)
+      const metadataText = await blob.text()
+      const metadata = JSON.parse(metadataText)
 
-        const blob = await beeApi.downloadFileWithACT(wrapper.ref, parsed.actPublisher, wrapper.history)
-        const metadataText = await blob.text()
-        const metadata = JSON.parse(metadataText)
+      const driveName = name.trim() || metadata.name || 'Shared drive'
+      const files: SharedFile[] | undefined = metadata.files?.length ? metadata.files : undefined
 
-        if (metadata.files?.length) files = metadata.files
-
-        driveName = name.trim() || metadata.name || 'Shared drive'
-        reference = wrapper.ref
-        actHistoryRef = wrapper.history
-      } else if (parsed.type === 'snapshot' && parsed.reference && parsed.actHistoryRef) {
-        // Legacy snapshot: direct ACT download
-        const blob = await beeApi.downloadFileWithACT(parsed.reference, parsed.actPublisher, parsed.actHistoryRef)
-        const text = await blob.text()
-
-        try {
-          const metadata = JSON.parse(text)
-
-          if (metadata.name) driveName = name.trim() || metadata.name
-
-          if (metadata.files?.length) files = metadata.files
-        } catch {
-          // Not JSON — single file
-        }
-
-        reference = parsed.reference
-        actHistoryRef = parsed.actHistoryRef
-      }
-
+      // Add the drive
       onAdd({
         name: driveName,
-        reference,
+        reference: wrapper.ref,
         actPublisher: parsed.actPublisher,
-        actHistoryRef,
+        actHistoryRef: wrapper.history,
         files,
-        feedTopic: parsed.type === 'feed' ? parsed.feedTopic : undefined,
-        feedOwner: parsed.type === 'feed' ? parsed.feedOwner : undefined,
+        feedTopic: parsed.feedTopic,
+        feedOwner: parsed.feedOwner,
       })
+
+      // Optionally add the sender as contact
+      if (showContactImport && addAsContact && sender) {
+        try {
+          addContact(existingContacts, {
+            id: sender.addr.toLowerCase(),
+            nickname: contactNickname.trim(),
+            walletPublicKey: sender.walletPublicKey,
+            beePublicKey: sender.beePublicKey,
+            source: 'drive-share',
+            addedAt: Date.now(),
+          })
+        } catch {
+          // Race with another tab adding the same contact — non-fatal
+        }
+      }
+
       onClose()
     } catch {
       setError('Could not access this drive. Make sure the owner has granted you access using your sharing key.')
@@ -142,11 +158,50 @@ export default function AddSharedDriveModal({ myPublicKey, onClose, onAdd }: Add
           <textarea
             value={link}
             onChange={e => setLink(e.target.value)}
-            placeholder="swarm://feed?topic=...&owner=...&publisher=..."
+            placeholder="nook://drive-share?topic=...&owner=...&publisher=...&addr=...&wpub=...&bpub=..."
             className="w-full rounded-lg border px-3 py-2 text-xs font-mono focus:outline-none resize-none h-20"
             style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))' }}
           />
         </div>
+
+        {/* Sender contact import — only when link includes contact info AND not already a contact */}
+        {showContactImport && sender && (
+          <div
+            className="rounded-lg border p-3 space-y-2"
+            style={{ backgroundColor: 'rgb(var(--bg))', borderColor: 'rgb(var(--border))' }}
+          >
+            <label className="flex items-start gap-2 text-xs cursor-pointer">
+              <input
+                type="checkbox"
+                checked={addAsContact}
+                onChange={e => setAddAsContact(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span style={{ color: 'rgb(var(--fg))' }}>
+                Also add sender as contact{' '}
+                <span className="font-mono" style={{ color: 'rgb(var(--fg-muted))' }}>
+                  ({sender.addr.slice(0, 8)}…{sender.addr.slice(-4)})
+                </span>
+              </span>
+            </label>
+            {addAsContact && (
+              <input
+                type="text"
+                value={contactNickname}
+                onChange={e => setContactNickname(e.target.value)}
+                placeholder="Nickname for this contact"
+                className="w-full rounded-lg border px-3 py-2 text-xs focus:outline-none"
+                style={{ backgroundColor: 'rgb(var(--bg-surface))', color: 'rgb(var(--fg))' }}
+              />
+            )}
+          </div>
+        )}
+
+        {sender && senderAlreadyContact && (
+          <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
+            Sender is already in your contacts.
+          </p>
+        )}
 
         {error && (
           <div className="space-y-2">

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -20,6 +20,8 @@ import { gnosis } from 'wagmi/chains'
 import { weiToDai } from '../api/bee'
 import { useBeeHealth, usePeers, useStamps, useStatus, useWallet } from '../api/queries'
 import { useInboxPolling } from '../hooks/useInboxPolling'
+import { useRegistryPolling } from '../hooks/useRegistryPolling'
+import { loadInvitations, pendingInvitations } from '../notify/invitations'
 import { loadReadCursors, loadThreads, totalUnread } from '../notify/messages'
 import { useAppStore } from '../store/app'
 import Onboarding from './Onboarding'
@@ -138,6 +140,9 @@ export default function Layout() {
   // Background inbox polling — keeps unread badge fresh whether or not the
   // Messages page is mounted. Side-effect hook; writes to localStorage threads.
   useInboxPolling()
+  // Background on-chain notification polling — surfaces wake-up pings from
+  // senders who aren't yet in our contact list (see #62/#63).
+  useRegistryPolling()
 
   // Total unread messages across all conversations — drives a badge on the
   // Messages sidebar entry. Re-reads localStorage on a short interval; cheap,
@@ -145,7 +150,12 @@ export default function Layout() {
   const [messagesUnread, setMessagesUnread] = useState(0)
 
   useEffect(() => {
-    const tick = () => setMessagesUnread(totalUnread(loadThreads(), loadReadCursors()))
+    const tick = () => {
+      const unread = totalUnread(loadThreads(), loadReadCursors())
+      const pending = pendingInvitations(loadInvitations()).length
+
+      setMessagesUnread(unread + pending)
+    }
 
     tick()
     const id = setInterval(tick, 3_000)

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -19,6 +19,8 @@ import { useAccount, useDisconnect, useSwitchChain } from 'wagmi'
 import { gnosis } from 'wagmi/chains'
 import { weiToDai } from '../api/bee'
 import { useBeeHealth, usePeers, useStamps, useStatus, useWallet } from '../api/queries'
+import { useInboxPolling } from '../hooks/useInboxPolling'
+import { loadReadCursors, loadThreads, totalUnread } from '../notify/messages'
 import { useAppStore } from '../store/app'
 import Onboarding from './Onboarding'
 
@@ -133,6 +135,24 @@ export default function Layout() {
 
   const navItems = devMode ? [...mainNavItems, { to: '/dev', icon: Terminal, label: 'Dev mode' }] : mainNavItems
 
+  // Background inbox polling — keeps unread badge fresh whether or not the
+  // Messages page is mounted. Side-effect hook; writes to localStorage threads.
+  useInboxPolling()
+
+  // Total unread messages across all conversations — drives a badge on the
+  // Messages sidebar entry. Re-reads localStorage on a short interval; cheap,
+  // and avoids needing a global store just for one indicator.
+  const [messagesUnread, setMessagesUnread] = useState(0)
+
+  useEffect(() => {
+    const tick = () => setMessagesUnread(totalUnread(loadThreads(), loadReadCursors()))
+
+    tick()
+    const id = setInterval(tick, 3_000)
+
+    return () => clearInterval(id)
+  }, [])
+
   // Track whether Bee has connected at least once this session.
   // Before that we show a friendly "starting" indicator instead of an error.
   const hasEverBeenOnline = useRef(false)
@@ -231,31 +251,45 @@ export default function Layout() {
           Apps
         </span>
         <nav className="flex flex-col gap-0.5 w-full px-2">
-          {appNavItems.map(({ to, icon: Icon, label, sublabel }) => (
-            <NavLink
-              key={to}
-              to={to}
-              onClick={() => navigate(to, { state: { ts: Date.now() } })}
-              className={({ isActive }) =>
-                [
-                  'flex flex-col items-center gap-0.5 py-2 rounded-lg transition-colors w-full',
-                  isActive ? 'text-white' : 'text-[rgb(var(--fg-muted))] hover:text-[rgb(var(--fg))]',
-                ].join(' ')
-              }
-              style={({ isActive }) => (isActive ? { backgroundColor: 'rgba(247,104,8,0.65)' } : {})}
-            >
-              <Icon size={15} />
-              <span className="text-[9px] font-medium leading-tight text-center">
-                {label}
-                {sublabel && (
-                  <>
-                    <br />
-                    {sublabel}
-                  </>
-                )}
-              </span>
-            </NavLink>
-          ))}
+          {appNavItems.map(({ to, icon: Icon, label, sublabel }) => {
+            const badge = to === '/apps/messages' ? messagesUnread : 0
+
+            return (
+              <NavLink
+                key={to}
+                to={to}
+                onClick={() => navigate(to, { state: { ts: Date.now() } })}
+                className={({ isActive }) =>
+                  [
+                    'flex flex-col items-center gap-0.5 py-2 rounded-lg transition-colors w-full relative',
+                    isActive ? 'text-white' : 'text-[rgb(var(--fg-muted))] hover:text-[rgb(var(--fg))]',
+                  ].join(' ')
+                }
+                style={({ isActive }) => (isActive ? { backgroundColor: 'rgba(247,104,8,0.65)' } : {})}
+              >
+                <div className="relative">
+                  <Icon size={15} />
+                  {badge > 0 && (
+                    <span
+                      className="absolute -top-1.5 -right-2 text-[8px] font-bold leading-none px-1 py-0.5 rounded-full min-w-[14px] text-center"
+                      style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+                    >
+                      {badge > 99 ? '99+' : badge}
+                    </span>
+                  )}
+                </div>
+                <span className="text-[9px] font-medium leading-tight text-center">
+                  {label}
+                  {sublabel && (
+                    <>
+                      <br />
+                      {sublabel}
+                    </>
+                  )}
+                </span>
+              </NavLink>
+            )
+          })}
         </nav>
 
         {/* Settings pinned to bottom */}

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -3,14 +3,20 @@
  * Paste a sharing key (Bee publicKey) to grant access.
  * Generate a share link for the grantee to add the drive.
  */
-import { Copy, Check, Lock, RefreshCw, Trash2, Users, X } from 'lucide-react'
+import { Bee } from '@ethersphere/bee-js'
+import { mailbox } from '@swarm-notify/sdk'
+import { Bell, Copy, Check, Lock, RefreshCw, Trash2, Users, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import { topicFromString } from '../api/bee'
 import { serverApi } from '../api/server'
 import { useDerivedKey } from '../hooks/useDerivedKey'
+import { appendSentDriveShare, loadThreads } from '../notify/messages'
 import { loadContacts } from '../notify/storage'
+import { toLibraryContact } from '../notify/types'
 import { buildShareLink } from '../hooks/useSharedDrives'
+
+const BEE_URL = `${window.location.origin}/bee-api`
 
 function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
@@ -62,12 +68,17 @@ export default function ShareModal({
 }: ShareModalProps) {
   const { signer } = useDerivedKey()
   const contacts = useMemo(() => loadContacts(), [])
+  const bee = useMemo(() => new Bee(BEE_URL), [])
 
   const [newKey, setNewKey] = useState('')
   const [newLabel, setNewLabel] = useState('')
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [grantees, setGrantees] = useState<string[]>([])
   const [senderName, setSenderName] = useState('')
+  // Per-grantee notification status keyed by lowercased contact id (Nook addr)
+  type NotifyStatus = 'idle' | 'sending' | 'sent' | 'failed'
+  const [notifyStatus, setNotifyStatus] = useState<Record<string, NotifyStatus>>({})
+  const [notifying, setNotifying] = useState(false)
   // Legacy: older grantees were saved with manual labels before contacts existed.
   // Read-only fallback for displaying their names; new grants pull from contacts.
   const [labels, setLabels] = useState<Record<string, string>>(() => {
@@ -276,6 +287,87 @@ export default function ShareModal({
     }
   }
 
+  /** Find the contact whose beePublicKey matches this grantee key, if any. */
+  function contactForGrantee(granteeKey: string) {
+    const keyX = stripKeyPrefix(granteeKey)
+
+    return contacts.find(c => stripKeyPrefix(c.beePublicKey) === keyX)
+  }
+
+  /**
+   * Grantees that can be notified — they're in the contact list (so we have
+   * their wpub for ECDH) and not us. Excludes already-sent recipients in the
+   * current session so re-clicks don't re-fire.
+   */
+  const notifiableGrantees = useMemo(
+    () =>
+      grantees
+        .filter(key => !isMyKey(key))
+        .map(key => ({ granteeKey: key, contact: contactForGrantee(key) }))
+        .filter((g): g is { granteeKey: string; contact: NonNullable<ReturnType<typeof contactForGrantee>> } =>
+          Boolean(g.contact),
+        ),
+    [grantees, contacts],
+  )
+
+  const pendingNotify = notifiableGrantees.filter(g => notifyStatus[g.contact.id] !== 'sent')
+
+  async function handleNotifyAll() {
+    if (!signer || !files?.length) return
+
+    if (pendingNotify.length === 0) return
+    setNotifying(true)
+    setError(null)
+
+    let link: string
+
+    try {
+      // Refresh the feed once before notifying — recipients all read the same
+      // metadata, so we don't pay this per-recipient.
+      link = await refreshAndBuildLink()
+    } catch (e) {
+      setError((e as Error).message || 'Failed to prepare drive link')
+      setNotifying(false)
+
+      return
+    }
+
+    const myAddr = signer.getAddress()
+    const fileCount = files.length
+    const subject = `"${driveName}" shared with you`
+    const body = `Drive shared. Open in Nook to add it.`
+
+    for (const { contact } of pendingNotify) {
+      setNotifyStatus(prev => ({ ...prev, [contact.id]: 'sending' }))
+      try {
+        await mailbox.send(
+          bee,
+          signer.getSigningKey(),
+          stampId,
+          signer.getSigningKey(),
+          myAddr,
+          toLibraryContact(contact),
+          {
+            subject,
+            body,
+            type: 'drive-share',
+            driveShareLink: link,
+            driveName,
+            fileCount,
+          },
+        )
+        // Save locally so the sender sees the message in their own thread
+        const threads = loadThreads()
+
+        appendSentDriveShare(threads, contact.id, { driveShareLink: link, driveName, fileCount })
+        setNotifyStatus(prev => ({ ...prev, [contact.id]: 'sent' }))
+      } catch {
+        setNotifyStatus(prev => ({ ...prev, [contact.id]: 'failed' }))
+      }
+    }
+    setNotifying(false)
+  }
+
   return (
     <div
       className="fixed inset-0 flex items-center justify-center z-50"
@@ -316,6 +408,8 @@ export default function ShareModal({
               grantees.map(key => {
                 const isMe = isMyKey(key)
                 const label = findLabel(key)
+                const contact = contactForGrantee(key)
+                const status = contact ? notifyStatus[contact.id] : undefined
 
                 return (
                   <div key={key} className="flex items-center justify-between px-3 py-2">
@@ -334,6 +428,39 @@ export default function ShareModal({
                           style={{ backgroundColor: 'rgba(74,222,128,0.12)', color: '#4ade80' }}
                         >
                           you
+                        </span>
+                      )}
+                      {!isMe && status === 'sent' && (
+                        <span
+                          className="ml-2 text-[10px] font-sans font-medium px-1.5 py-0.5 rounded"
+                          style={{ backgroundColor: 'rgba(74,222,128,0.12)', color: '#4ade80' }}
+                        >
+                          notified
+                        </span>
+                      )}
+                      {!isMe && status === 'sending' && (
+                        <span
+                          className="ml-2 text-[10px] font-sans font-medium px-1.5 py-0.5 rounded"
+                          style={{ color: 'rgb(var(--fg-muted))' }}
+                        >
+                          sending…
+                        </span>
+                      )}
+                      {!isMe && status === 'failed' && (
+                        <span
+                          className="ml-2 text-[10px] font-sans font-medium px-1.5 py-0.5 rounded"
+                          style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
+                        >
+                          failed
+                        </span>
+                      )}
+                      {!isMe && !contact && (
+                        <span
+                          className="ml-2 text-[10px] font-sans px-1.5 py-0.5 rounded"
+                          style={{ color: 'rgb(var(--fg-muted))' }}
+                          title="Add this person to Contacts to enable in-app notifications"
+                        >
+                          not in contacts
                         </span>
                       )}
                     </span>
@@ -464,6 +591,33 @@ export default function ShareModal({
                 )}
                 {loading ? 'Generating…' : copiedLink ? 'Link copied!' : 'Copy drive link'}
               </button>
+
+              {/* Notify in Messages — sends a typed drive-share message to each
+                  contact-grantee. Skips grantees not in the contact list. */}
+              {notifiableGrantees.length > 0 && (
+                <button
+                  onClick={handleNotifyAll}
+                  disabled={notifying || pendingNotify.length === 0}
+                  className="w-full py-2 rounded-lg text-xs font-semibold flex items-center justify-center gap-1.5 disabled:opacity-40 transition-colors border"
+                  style={{
+                    backgroundColor: 'rgb(var(--bg))',
+                    color: 'rgb(var(--fg))',
+                    borderColor: 'rgb(var(--border))',
+                  }}
+                  title={
+                    pendingNotify.length === 0
+                      ? 'All eligible grantees already notified in this session'
+                      : `Send a Messages notification to ${pendingNotify.length} contact${pendingNotify.length === 1 ? '' : 's'}`
+                  }
+                >
+                  {notifying ? <RefreshCw size={11} className="animate-spin" /> : <Bell size={11} />}
+                  {notifying
+                    ? 'Sending…'
+                    : pendingNotify.length === 0
+                      ? 'All notified'
+                      : `Send notification to ${pendingNotify.length} contact${pendingNotify.length === 1 ? '' : 's'}`}
+                </button>
+              )}
             </div>
           )}
 

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -4,19 +4,28 @@
  * Generate a share link for the grantee to add the drive.
  */
 import { Bee } from '@ethersphere/bee-js'
-import { mailbox } from '@swarm-notify/sdk'
+import { mailbox, registry } from '@swarm-notify/sdk'
 import { Bell, Copy, Check, Lock, RefreshCw, Trash2, Users, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { useWalletClient } from 'wagmi'
 
 import { topicFromString } from '../api/bee'
 import { serverApi } from '../api/server'
 import { useDerivedKey } from '../hooks/useDerivedKey'
+import { GNOSIS_CHAIN_ID, REGISTRY_ADDRESS } from '../notify/constants'
 import { appendSentDriveShare, loadThreads } from '../notify/messages'
+import { createNotifyProvider } from '../notify/provider'
 import { loadContacts } from '../notify/storage'
 import { toLibraryContact } from '../notify/types'
 import { buildShareLink } from '../hooks/useSharedDrives'
 
 const BEE_URL = `${window.location.origin}/bee-api`
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+
+  return new Uint8Array(clean.match(/.{2}/g)!.map(b => parseInt(b, 16)))
+}
 
 function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
@@ -67,6 +76,7 @@ export default function ShareModal({
   onUpdate,
 }: ShareModalProps) {
   const { signer } = useDerivedKey()
+  const { data: walletClient } = useWalletClient()
   const contacts = useMemo(() => loadContacts(), [])
   const bee = useMemo(() => new Bee(BEE_URL), [])
 
@@ -79,6 +89,10 @@ export default function ShareModal({
   type NotifyStatus = 'idle' | 'sending' | 'sent' | 'failed'
   const [notifyStatus, setNotifyStatus] = useState<Record<string, NotifyStatus>>({})
   const [notifying, setNotifying] = useState(false)
+  // Optional on-chain wake-up — fires a Gnosis registry event so recipients
+  // who haven't added you yet still get a "someone wants to reach you" signal.
+  const [sendOnChain, setSendOnChain] = useState(false)
+  const [onChainStatus, setOnChainStatus] = useState<Record<string, NotifyStatus>>({})
   // Legacy: older grantees were saved with manual labels before contacts existed.
   // Read-only fallback for displaying their names; new grants pull from contacts.
   const [labels, setLabels] = useState<Record<string, string>>(() => {
@@ -313,9 +327,33 @@ export default function ShareModal({
   const pendingNotify = notifiableGrantees.filter(g => notifyStatus[g.contact.id] !== 'sent')
 
   async function handleNotifyAll() {
-    if (!signer || !files?.length) return
+    if (!signer) {
+      setError('No Nook key — derive your key on the Contacts page (it resets on every reload).')
+
+      return
+    }
+
+    if (!files?.length) {
+      setError('Drive has no files to share yet.')
+
+      return
+    }
 
     if (pendingNotify.length === 0) return
+
+    if (sendOnChain) {
+      if (!walletClient) {
+        setError('Connect a wallet to send on-chain wake-up notifications.')
+
+        return
+      }
+
+      if (walletClient.chain?.id !== GNOSIS_CHAIN_ID) {
+        setError(`Switch wallet to Gnosis Chain (id ${GNOSIS_CHAIN_ID}) for on-chain wake-up.`)
+
+        return
+      }
+    }
     setNotifying(true)
     setError(null)
 
@@ -336,6 +374,9 @@ export default function ShareModal({
     const fileCount = files.length
     const subject = `"${driveName}" shared with you`
     const body = `Drive shared. Open in Nook to add it.`
+    const provider = sendOnChain && walletClient ? createNotifyProvider(walletClient) : null
+
+    let lastFailMsg: string | null = null
 
     for (const { contact } of pendingNotify) {
       setNotifyStatus(prev => ({ ...prev, [contact.id]: 'sending' }))
@@ -361,10 +402,36 @@ export default function ShareModal({
 
         appendSentDriveShare(threads, contact.id, { driveShareLink: link, driveName, fileCount })
         setNotifyStatus(prev => ({ ...prev, [contact.id]: 'sent' }))
-      } catch {
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(`Notify ${contact.nickname} failed:`, e)
+        lastFailMsg = (e as Error).message ?? 'send failed'
         setNotifyStatus(prev => ({ ...prev, [contact.id]: 'failed' }))
       }
+
+      // On-chain wake-up — fired AFTER mailbox so the message is already in
+      // the feed by the time recipient discovers the event and resolves us.
+      if (provider) {
+        setOnChainStatus(prev => ({ ...prev, [contact.id]: 'sending' }))
+        try {
+          const recipientPubKey = hexToBytes(contact.walletPublicKey)
+          const txHash = await registry.sendNotification(provider, REGISTRY_ADDRESS, recipientPubKey, contact.id, {
+            sender: myAddr,
+          })
+
+          // eslint-disable-next-line no-console
+          console.log(`On-chain wake-up to ${contact.nickname}: tx ${txHash}`)
+          setOnChainStatus(prev => ({ ...prev, [contact.id]: 'sent' }))
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.error(`On-chain notify ${contact.nickname} failed:`, e)
+          lastFailMsg = (e as Error).message ?? 'on-chain send failed'
+          setOnChainStatus(prev => ({ ...prev, [contact.id]: 'failed' }))
+        }
+      }
     }
+
+    if (lastFailMsg) setError(`Notification send failed: ${lastFailMsg}`)
     setNotifying(false)
   }
 
@@ -436,6 +503,22 @@ export default function ShareModal({
                           style={{ backgroundColor: 'rgba(74,222,128,0.12)', color: '#4ade80' }}
                         >
                           notified
+                        </span>
+                      )}
+                      {!isMe && contact && onChainStatus[contact.id] === 'sent' && (
+                        <span
+                          className="ml-1 text-[10px] font-sans font-medium px-1.5 py-0.5 rounded"
+                          style={{ backgroundColor: 'rgba(96,165,250,0.12)', color: '#60a5fa' }}
+                        >
+                          + on-chain
+                        </span>
+                      )}
+                      {!isMe && contact && onChainStatus[contact.id] === 'failed' && (
+                        <span
+                          className="ml-1 text-[10px] font-sans font-medium px-1.5 py-0.5 rounded"
+                          style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
+                        >
+                          on-chain failed
                         </span>
                       )}
                       {!isMe && status === 'sending' && (
@@ -594,30 +677,60 @@ export default function ShareModal({
 
               {/* Notify in Messages — sends a typed drive-share message to each
                   contact-grantee. Skips grantees not in the contact list. */}
-              {notifiableGrantees.length > 0 && (
-                <button
-                  onClick={handleNotifyAll}
-                  disabled={notifying || pendingNotify.length === 0}
-                  className="w-full py-2 rounded-lg text-xs font-semibold flex items-center justify-center gap-1.5 disabled:opacity-40 transition-colors border"
-                  style={{
-                    backgroundColor: 'rgb(var(--bg))',
-                    color: 'rgb(var(--fg))',
-                    borderColor: 'rgb(var(--border))',
-                  }}
-                  title={
-                    pendingNotify.length === 0
-                      ? 'All eligible grantees already notified in this session'
-                      : `Send a Messages notification to ${pendingNotify.length} contact${pendingNotify.length === 1 ? '' : 's'}`
-                  }
-                >
-                  {notifying ? <RefreshCw size={11} className="animate-spin" /> : <Bell size={11} />}
-                  {notifying
-                    ? 'Sending…'
-                    : pendingNotify.length === 0
-                      ? 'All notified'
-                      : `Send notification to ${pendingNotify.length} contact${pendingNotify.length === 1 ? '' : 's'}`}
-                </button>
-              )}
+              {notifiableGrantees.length > 0 &&
+                (() => {
+                  const names = pendingNotify.map(p => p.contact.nickname)
+                  let recipients: string
+
+                  if (names.length === 0) recipients = ''
+                  else if (names.length <= 2) recipients = names.join(', ')
+                  else recipients = `${names.length} contacts`
+
+                  return (
+                    <>
+                      <button
+                        onClick={handleNotifyAll}
+                        disabled={notifying || pendingNotify.length === 0}
+                        className="w-full py-2 rounded-lg text-xs font-semibold flex items-center justify-center gap-1.5 disabled:opacity-40 transition-colors border"
+                        style={{
+                          backgroundColor: 'rgb(var(--bg))',
+                          color: 'rgb(var(--fg))',
+                          borderColor: 'rgb(var(--border))',
+                        }}
+                        title={
+                          pendingNotify.length === 0
+                            ? 'All eligible grantees already notified in this session'
+                            : `Send a Messages notification to ${recipients}`
+                        }
+                      >
+                        {notifying ? <RefreshCw size={11} className="animate-spin" /> : <Bell size={11} />}
+                        {notifying
+                          ? 'Sending…'
+                          : pendingNotify.length === 0
+                            ? 'All notified'
+                            : `Send notification to ${recipients}`}
+                      </button>
+
+                      {/* On-chain wake-up toggle — useful when recipient hasn't
+                          added you back yet, so mailbox poll wouldn't pick it up. */}
+                      <label
+                        className="flex items-start gap-2 text-[11px] cursor-pointer pt-1"
+                        style={{ color: 'rgb(var(--fg-muted))' }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={sendOnChain}
+                          onChange={e => setSendOnChain(e.target.checked)}
+                          className="mt-0.5"
+                        />
+                        <span>
+                          Also send on-chain wake-up (~0.001 xDAI) — for recipients who haven&apos;t added you back yet.
+                          Requires wallet on Gnosis Chain.
+                        </span>
+                      </label>
+                    </>
+                  )
+                })()}
             </div>
           )}
 

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -4,7 +4,7 @@
  * Generate a share link for the grantee to add the drive.
  */
 import { Bee } from '@ethersphere/bee-js'
-import { mailbox, registry } from '@swarm-notify/sdk'
+import { identity, mailbox, registry } from '@swarm-notify/sdk'
 import { Bell, Copy, Check, Lock, RefreshCw, Trash2, Users, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useWalletClient } from 'wagmi'
@@ -15,7 +15,7 @@ import { useDerivedKey } from '../hooks/useDerivedKey'
 import { GNOSIS_CHAIN_ID, REGISTRY_ADDRESS } from '../notify/constants'
 import { appendSentDriveShare, loadThreads } from '../notify/messages'
 import { createNotifyProvider } from '../notify/provider'
-import { loadContacts } from '../notify/storage'
+import { addContact, loadContacts } from '../notify/storage'
 import { toLibraryContact } from '../notify/types'
 import { buildShareLink } from '../hooks/useSharedDrives'
 
@@ -61,6 +61,10 @@ function isValidPublicKey(key: string): boolean {
 
   // Compressed (66 hex = 33 bytes) or uncompressed (130 hex = 65 bytes)
   return /^[0-9a-fA-F]+$/.test(clean) && (clean.length === 66 || clean.length === 130)
+}
+
+function isEthAddress(s: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(s.trim())
 }
 
 export default function ShareModal({
@@ -185,18 +189,54 @@ export default function ShareModal({
   }
 
   async function handleGrant() {
-    const key = newKey.trim()
-
-    if (!isValidPublicKey(key)) {
-      setError('Invalid sharing key. Must be a 66 or 130 character hex public key.')
-
-      return
-    }
+    const input = newKey.trim()
+    let key = input
 
     setLoading(true)
     setError(null)
 
     try {
+      // Accept Nook address as input — resolve via identity feed to bpub.
+      // Saves the user from hunting for the raw sharing key when they only
+      // have the recipient's address (eg first-contact scenario).
+      if (isEthAddress(input)) {
+        const resolved = await identity.resolve(bee, input)
+
+        if (!resolved) {
+          setError(
+            `Could not find identity for ${input}. They must publish first, or paste their sharing key directly.`,
+          )
+
+          return
+        }
+        key = resolved.beePublicKey
+        // If we resolved an address and have a label, save the contact so
+        // the user doesn't repeat this lookup next time.
+        const alreadyContact = contacts.some(c => c.id.toLowerCase() === input.toLowerCase())
+
+        if (!alreadyContact && newLabel.trim()) {
+          try {
+            // Persists to localStorage; in-memory `contacts` here stays stale
+            // until next render, which is fine — only matters for repeat
+            // grants in the same modal session.
+            addContact(contacts, {
+              id: input.toLowerCase(),
+              nickname: newLabel.trim(),
+              walletPublicKey: resolved.walletPublicKey,
+              beePublicKey: resolved.beePublicKey,
+              source: 'identity-feed',
+              addedAt: Date.now(),
+            })
+          } catch {
+            // Race: contact added in another tab — non-fatal
+          }
+        }
+      } else if (!isValidPublicKey(input)) {
+        setError('Paste a Nook address (0x… 42 chars) or a 66/130-char hex sharing key.')
+
+        return
+      }
+
       let result
 
       if (granteeRef && actHistoryRef) {
@@ -208,8 +248,9 @@ export default function ShareModal({
 
       setGrantees(prev => [...prev, key])
 
-      // If user typed a manual label for someone NOT in their contact list,
-      // remember it (legacy behavior) so the grantee row shows a name.
+      // If user typed a manual label for someone NOT in their contact list
+      // (and we didn't already save them via address resolve), remember it
+      // so the grantee row shows a name.
       const matchedContact = contacts.find(c => stripKeyPrefix(c.beePublicKey) === stripKeyPrefix(key))
 
       if (newLabel.trim() && !matchedContact) saveLabel(key, newLabel.trim())
@@ -621,7 +662,7 @@ export default function ShareModal({
                 type="text"
                 value={newKey}
                 onChange={e => setNewKey(e.target.value)}
-                placeholder="Paste their sharing key"
+                placeholder="Nook address (0x…) or sharing key"
                 className="flex-1 rounded-lg border px-3 py-2 text-xs font-mono focus:outline-none"
                 style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))' }}
               />

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -223,48 +223,54 @@ export default function ShareModal({
     }
   }
 
-  async function copyShareLink() {
-    if (!actPublisher || !actHistoryRef || !beeAddress || !files?.length) return
+  /**
+   * Re-upload metadata with the latest ACT history (so newly-granted users can
+   * read it) and update the feed pointer. Returns the share link.
+   *
+   * Both Copy link and Send notification need to do this — extracted so the
+   * recipient never gets a stale link pointing at metadata they can't decrypt.
+   */
+  async function refreshAndBuildLink(): Promise<string> {
+    if (!actPublisher || !actHistoryRef || !beeAddress || !files?.length) {
+      throw new Error('Drive is not ready to share yet')
+    }
 
     if (!signer || !myPublicKey) {
-      setError('Derive your Nook key first (Contacts page) so the link can carry your contact info.')
-
-      return
+      throw new Error('Derive your Nook key first (Contacts page) so the link can carry your contact info.')
     }
+    const topic = await topicFromString(stampId + 'nook-drive-meta')
+    const metadata = JSON.stringify({
+      files: files.map(f => ({ name: f.name, reference: f.reference, historyRef: f.historyRef, size: f.size })),
+    })
+    const uploaded = await serverApi.uploadACTMetadata(stampId, metadata, actHistoryRef)
+    const wrapper = JSON.stringify({ ref: uploaded.reference, history: uploaded.historyRef })
+    const wrapperResult = await serverApi.uploadRawBytes(stampId, wrapper)
+
+    await serverApi.createFeedUpdate(topic, wrapperResult.reference, stampId)
+
+    return buildShareLink({
+      feedTopic: topic,
+      feedOwner: beeAddress,
+      actPublisher,
+      sender: {
+        addr: signer.getAddress(),
+        walletPublicKey: bytesToHex(signer.getPublicKey()),
+        name: senderName.trim() || undefined,
+      },
+    })
+  }
+
+  async function copyShareLink() {
     setLoading(true)
     setError(null)
-
     try {
-      const topic = await topicFromString(stampId + 'nook-drive-meta')
-
-      // Re-upload metadata with LATEST history (includes all grantees) and update feed
-      const metadata = JSON.stringify({
-        files: files.map(f => ({ name: f.name, reference: f.reference, historyRef: f.historyRef, size: f.size })),
-      })
-      const uploaded = await serverApi.uploadACTMetadata(stampId, metadata, actHistoryRef)
-
-      // Upload wrapper as raw bytes (not /bzz file) so feed reader can use /bytes to read it
-      const wrapper = JSON.stringify({ ref: uploaded.reference, history: uploaded.historyRef })
-      const wrapperResult = await serverApi.uploadRawBytes(stampId, wrapper)
-
-      await serverApi.createFeedUpdate(topic, wrapperResult.reference, stampId)
-
-      const link = buildShareLink({
-        feedTopic: topic,
-        feedOwner: beeAddress,
-        actPublisher,
-        sender: {
-          addr: signer.getAddress(),
-          walletPublicKey: bytesToHex(signer.getPublicKey()),
-          name: senderName.trim() || undefined,
-        },
-      })
+      const link = await refreshAndBuildLink()
 
       navigator.clipboard.writeText(link)
       setCopiedLink(true)
       setTimeout(() => setCopiedLink(false), 2000)
-    } catch {
-      setError('Failed to generate share link')
+    } catch (e) {
+      setError((e as Error).message || 'Failed to generate share link')
     } finally {
       setLoading(false)
     }

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -256,7 +256,6 @@ export default function ShareModal({
         sender: {
           addr: signer.getAddress(),
           walletPublicKey: bytesToHex(signer.getPublicKey()),
-          beePublicKey: myPublicKey,
           name: senderName.trim() || undefined,
         },
       })

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -372,7 +372,11 @@ export default function ShareModal({
 
     const myAddr = signer.getAddress()
     const fileCount = files.length
-    const subject = `"${driveName}" shared with you`
+    // Subject leads with sender name so a recipient peeking at the feed (eg
+    // from an on-chain invitation, before adding us as contact) sees who.
+    const subject = senderName.trim()
+      ? `${senderName.trim()} shared "${driveName}" with you`
+      : `"${driveName}" shared with you`
     const body = `Drive shared. Open in Nook to add it.`
     const provider = sendOnChain && walletClient ? createNotifyProvider(walletClient) : null
 

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -4,10 +4,19 @@
  * Generate a share link for the grantee to add the drive.
  */
 import { Copy, Check, Lock, RefreshCw, Trash2, Users, X } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { topicFromString } from '../api/bee'
 import { serverApi } from '../api/server'
+import { useDerivedKey } from '../hooks/useDerivedKey'
+import { loadContacts } from '../notify/storage'
+import { buildShareLink } from '../hooks/useSharedDrives'
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
 
 interface ShareFileEntry {
   name: string
@@ -51,10 +60,16 @@ export default function ShareModal({
   onClose,
   onUpdate,
 }: ShareModalProps) {
+  const { signer } = useDerivedKey()
+  const contacts = useMemo(() => loadContacts(), [])
+
   const [newKey, setNewKey] = useState('')
   const [newLabel, setNewLabel] = useState('')
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [grantees, setGrantees] = useState<string[]>([])
+  const [senderName, setSenderName] = useState('')
+  // Legacy: older grantees were saved with manual labels before contacts existed.
+  // Read-only fallback for displaying their names; new grants pull from contacts.
   const [labels, setLabels] = useState<Record<string, string>>(() => {
     try {
       return JSON.parse(localStorage.getItem('nook-grantee-labels') ?? '{}')
@@ -95,11 +110,15 @@ export default function ShareModal({
     return clean
   }
 
-  /** Find a label for a key, matching compressed vs uncompressed formats */
+  /** Find a label for a key — prefers contact list, falls back to legacy label map. */
   function findLabel(key: string): string | undefined {
-    if (labels[key]) return labels[key]
-
     const keyX = stripKeyPrefix(key)
+
+    for (const c of contacts) {
+      if (stripKeyPrefix(c.beePublicKey) === keyX) return c.nickname
+    }
+
+    if (labels[key]) return labels[key]
 
     for (const [storedKey, label] of Object.entries(labels)) {
       if (stripKeyPrefix(storedKey) === keyX) return label
@@ -115,24 +134,21 @@ export default function ShareModal({
     return stripKeyPrefix(key) === stripKeyPrefix(myPublicKey)
   }
 
-  // Contact suggestions — filter from grantee labels, exclude already-added grantees
-  const contactSuggestions: [string, string][] = Object.entries(labels)
-    .filter(([key, label]) => {
-      // Exclude own key
-      if (isMyKey(key)) return false
+  // Contact suggestions — sourced from the main contact list (nook-contacts-v2),
+  // so adding someone in the Contacts page makes them available here without
+  // re-typing keys. Excludes self and already-granted contacts.
+  const contactSuggestions: [string, string][] = contacts
+    .filter(c => {
+      if (isMyKey(c.beePublicKey)) return false
 
-      // Exclude already-added grantees
-      if (grantees.some(g => stripKeyPrefix(g) === stripKeyPrefix(key))) return false
+      if (grantees.some(g => stripKeyPrefix(g) === stripKeyPrefix(c.beePublicKey))) return false
 
-      // Filter by typed name
-      if (newLabel.trim()) {
-        return label.toLowerCase().includes(newLabel.toLowerCase())
-      }
+      if (newLabel.trim()) return c.nickname.toLowerCase().includes(newLabel.toLowerCase())
 
-      // Show all contacts when input is empty/focused
       return true
     })
-    .slice(0, 6) // Max 6 suggestions
+    .map<[string, string]>(c => [c.beePublicKey, c.nickname])
+    .slice(0, 6)
 
   // Load existing grantees on first render
   if (!loadedGrantees && granteeRef) {
@@ -167,7 +183,11 @@ export default function ShareModal({
 
       setGrantees(prev => [...prev, key])
 
-      if (newLabel.trim()) saveLabel(key, newLabel.trim())
+      // If user typed a manual label for someone NOT in their contact list,
+      // remember it (legacy behavior) so the grantee row shows a name.
+      const matchedContact = contacts.find(c => stripKeyPrefix(c.beePublicKey) === stripKeyPrefix(key))
+
+      if (newLabel.trim() && !matchedContact) saveLabel(key, newLabel.trim())
 
       setNewKey('')
       setNewLabel('')
@@ -205,7 +225,14 @@ export default function ShareModal({
 
   async function copyShareLink() {
     if (!actPublisher || !actHistoryRef || !beeAddress || !files?.length) return
+
+    if (!signer || !myPublicKey) {
+      setError('Derive your Nook key first (Contacts page) so the link can carry your contact info.')
+
+      return
+    }
     setLoading(true)
+    setError(null)
 
     try {
       const topic = await topicFromString(stampId + 'nook-drive-meta')
@@ -222,7 +249,18 @@ export default function ShareModal({
 
       await serverApi.createFeedUpdate(topic, wrapperResult.reference, stampId)
 
-      const link = `swarm://feed?topic=${topic}&owner=${beeAddress}&publisher=${actPublisher}`
+      const link = buildShareLink({
+        feedTopic: topic,
+        feedOwner: beeAddress,
+        actPublisher,
+        sender: {
+          addr: signer.getAddress(),
+          walletPublicKey: bytesToHex(signer.getPublicKey()),
+          beePublicKey: myPublicKey,
+          name: senderName.trim() || undefined,
+        },
+      })
+
       navigator.clipboard.writeText(link)
       setCopiedLink(true)
       setTimeout(() => setCopiedLink(false), 2000)
@@ -392,8 +430,17 @@ export default function ShareModal({
           {actPublisher && beeAddress && grantees.length > 0 && (
             <div className="space-y-2">
               <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
-                After granting access, send them the drive link:
+                After granting access, send them the drive link. The link also bundles your contact info so they can add
+                you in one click.
               </p>
+              <input
+                type="text"
+                value={senderName}
+                onChange={e => setSenderName(e.target.value)}
+                placeholder="Your name (optional, shown to recipient)"
+                className="w-full rounded-lg border px-3 py-2 text-xs focus:outline-none"
+                style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))' }}
+              />
               <button
                 onClick={copyShareLink}
                 disabled={loading}

--- a/ui/src/hooks/useInboxPolling.ts
+++ b/ui/src/hooks/useInboxPolling.ts
@@ -30,13 +30,15 @@ export function useInboxPolling(): void {
     let cancelled = false
 
     const poll = async () => {
+      const myAddr = signer.getAddress()
       // Re-read contacts each tick — the user may add a contact between polls.
-      const contacts = loadContacts()
+      // Filter out self: if a user adds their own share link as a contact (eg
+      // for solo testing), every poll otherwise hits myAddr→myAddr (404).
+      const contacts = loadContacts().filter(c => c.id.toLowerCase() !== myAddr.toLowerCase())
 
       if (contacts.length === 0) return
 
       try {
-        const myAddr = signer.getAddress()
         const inbox = await mailbox.checkInbox(bee, signer.getSigningKey(), myAddr, contacts.map(toLibraryContact))
 
         if (cancelled) return

--- a/ui/src/hooks/useInboxPolling.ts
+++ b/ui/src/hooks/useInboxPolling.ts
@@ -1,0 +1,66 @@
+/**
+ * Background inbox polling — runs at the Layout level so messages keep
+ * arriving (and the unread badge updates) even when the Messages page
+ * isn't mounted.
+ *
+ * Side-effect only: fetches new messages from each contact's mailbox feed,
+ * merges them into the localStorage threads store. Components reading
+ * threads from localStorage (Messages page, Layout badge) pick up the
+ * changes on their next render or interval tick.
+ */
+import { Bee } from '@ethersphere/bee-js'
+import { mailbox } from '@swarm-notify/sdk'
+import { useEffect, useMemo } from 'react'
+
+import { loadThreads, mergeReceived, saveThreads } from '../notify/messages'
+import { loadContacts } from '../notify/storage'
+import { toLibraryContact } from '../notify/types'
+import { useDerivedKey } from './useDerivedKey'
+
+const BEE_URL = `${window.location.origin}/bee-api`
+const POLL_INTERVAL_MS = 30_000
+
+export function useInboxPolling(): void {
+  const { signer } = useDerivedKey()
+  const bee = useMemo(() => new Bee(BEE_URL), [])
+
+  useEffect(() => {
+    if (!signer) return
+
+    let cancelled = false
+
+    const poll = async () => {
+      // Re-read contacts each tick — the user may add a contact between polls.
+      const contacts = loadContacts()
+
+      if (contacts.length === 0) return
+
+      try {
+        const myAddr = signer.getAddress()
+        const inbox = await mailbox.checkInbox(bee, signer.getSigningKey(), myAddr, contacts.map(toLibraryContact))
+
+        if (cancelled) return
+        // Merge directly into stored threads so the on-disk view is the
+        // source of truth for both Messages and the sidebar badge.
+        let threads = loadThreads()
+
+        for (const { contact, messages } of inbox) {
+          threads = mergeReceived(threads, contact.ethAddress, messages)
+        }
+        // mergeReceived already persists per call, but call once more here
+        // for clarity in case the loop body ever changes.
+        saveThreads(threads)
+      } catch {
+        // Network blips happen; the next tick will retry. Don't spam the UI.
+      }
+    }
+
+    void poll()
+    const id = setInterval(() => void poll(), POLL_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [signer, bee])
+}

--- a/ui/src/hooks/useRegistryPolling.ts
+++ b/ui/src/hooks/useRegistryPolling.ts
@@ -1,0 +1,74 @@
+/**
+ * Background polling for the on-chain notification registry. Companion to
+ * useInboxPolling — surfaces wake-up pings from senders who aren't yet in
+ * the local contact list.
+ *
+ * RPC calls don't cost gas, but they're slower than feed reads. Poll less
+ * aggressively than the mailbox.
+ */
+import { registry } from '@swarm-notify/sdk'
+import { useEffect } from 'react'
+
+import { addInvitation, getRegistryCursor, loadInvitations, setRegistryCursor } from '../notify/invitations'
+import { REGISTRY_ADDRESS } from '../notify/constants'
+import { createNotifyProvider } from '../notify/provider'
+import { loadContacts } from '../notify/storage'
+import { useDerivedKey } from './useDerivedKey'
+
+const POLL_INTERVAL_MS = 2 * 60_000 // 2 minutes
+
+export function useRegistryPolling(): void {
+  const { signer } = useDerivedKey()
+
+  useEffect(() => {
+    if (!signer) return
+
+    let cancelled = false
+    const provider = createNotifyProvider() // RPC-only, no walletClient needed for reads
+
+    const poll = async () => {
+      try {
+        const myAddr = signer.getAddress()
+        const fromBlock = getRegistryCursor(myAddr)
+        const notifications = await registry.pollNotifications(
+          provider,
+          REGISTRY_ADDRESS,
+          myAddr,
+          signer.getSigningKey(),
+          fromBlock,
+        )
+
+        if (cancelled || notifications.length === 0) return
+
+        const contacts = loadContacts()
+        const knownAddrs = new Set(contacts.map(c => c.id.toLowerCase()))
+        let invitations = loadInvitations()
+        let highestBlock = fromBlock
+
+        for (const { payload, blockNumber } of notifications) {
+          if (blockNumber > highestBlock) highestBlock = blockNumber
+
+          const senderId = payload.sender.toLowerCase()
+
+          // Skip: already a contact (mailbox poll will deliver their messages)
+          if (knownAddrs.has(senderId)) continue
+          invitations = addInvitation(invitations, senderId, blockNumber)
+        }
+
+        // Advance cursor past the latest block we processed so next poll is incremental
+        if (highestBlock > fromBlock) setRegistryCursor(myAddr, highestBlock + 1)
+      } catch {
+        // Spam decryption-fails are silently ignored by the SDK; other errors
+        // (RPC blip, etc) we just retry on next tick.
+      }
+    }
+
+    void poll()
+    const id = setInterval(() => void poll(), POLL_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [signer])
+}

--- a/ui/src/hooks/useSharedDrives.ts
+++ b/ui/src/hooks/useSharedDrives.ts
@@ -39,7 +39,11 @@ function persist(drives: SharedDrive[]) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(drives))
 }
 
-/** Sender's contact info embedded in a drive-share link. */
+/**
+ * Sender's contact info derived from a drive-share link.
+ * `beePublicKey` is reconstructed from the link's `publisher` field — no
+ * separate `bpub` is carried in the URL (it'd duplicate `publisher`).
+ */
 export interface SenderContactInfo {
   addr: string
   walletPublicKey: string
@@ -58,7 +62,8 @@ export interface ParsedShareLink {
 /**
  * Parse a `nook://drive-share?...` link.
  * Required params: topic, owner, publisher.
- * Optional contact bundle: addr + wpub + bpub (+ optional name).
+ * Optional contact bundle: addr + wpub (+ optional name).
+ * `publisher` doubles as the sender's Bee pubkey when contact info is present.
  *
  * Legacy `swarm://feed?...` links are NOT accepted — pre-release schema break.
  */
@@ -77,9 +82,8 @@ export function parseShareLink(link: string): ParsedShareLink | null {
 
     const addr = params.get('addr')
     const wpub = params.get('wpub')
-    const bpub = params.get('bpub')
     const name = params.get('name') ?? undefined
-    const sender = addr && wpub && bpub ? { addr, walletPublicKey: wpub, beePublicKey: bpub, name } : undefined
+    const sender = addr && wpub ? { addr, walletPublicKey: wpub, beePublicKey: actPublisher, name } : undefined
 
     return { feedTopic, feedOwner, actPublisher, sender }
   } catch {
@@ -87,12 +91,15 @@ export function parseShareLink(link: string): ParsedShareLink | null {
   }
 }
 
-/** Build a share link. Throws if any required field is missing. */
+/**
+ * Build a share link. The sender's `beePublicKey` MUST equal `actPublisher` —
+ * the link only encodes it once via `publisher`.
+ */
 export function buildShareLink(args: {
   feedTopic: string
   feedOwner: string
   actPublisher: string
-  sender: SenderContactInfo
+  sender: Omit<SenderContactInfo, 'beePublicKey'>
 }): string {
   const params = new URLSearchParams({
     topic: args.feedTopic,
@@ -100,7 +107,6 @@ export function buildShareLink(args: {
     publisher: args.actPublisher,
     addr: args.sender.addr,
     wpub: args.sender.walletPublicKey,
-    bpub: args.sender.beePublicKey,
   })
 
   if (args.sender.name) params.set('name', args.sender.name)

--- a/ui/src/hooks/useSharedDrives.ts
+++ b/ui/src/hooks/useSharedDrives.ts
@@ -39,49 +39,73 @@ function persist(drives: SharedDrive[]) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(drives))
 }
 
-export interface ParsedShareLink {
-  type: 'feed' | 'snapshot'
-  // Feed-based (live)
-  feedTopic?: string
-  feedOwner?: string
-  actPublisher: string
-  // Snapshot-based (legacy)
-  reference?: string
-  actHistoryRef?: string
+/** Sender's contact info embedded in a drive-share link. */
+export interface SenderContactInfo {
+  addr: string
+  walletPublicKey: string
+  beePublicKey: string
+  name?: string
 }
 
-/** Parse a share link into its components. Supports both feed-based and legacy snapshot links. */
+export interface ParsedShareLink {
+  feedTopic: string
+  feedOwner: string
+  actPublisher: string
+  /** Present when sender bundled contact info in the link. */
+  sender?: SenderContactInfo
+}
+
+/**
+ * Parse a `nook://drive-share?...` link.
+ * Required params: topic, owner, publisher.
+ * Optional contact bundle: addr + wpub + bpub (+ optional name).
+ *
+ * Legacy `swarm://feed?...` links are NOT accepted — pre-release schema break.
+ */
 export function parseShareLink(link: string): ParsedShareLink | null {
   try {
-    const clean = link.trim().replace('swarm://', '')
-    const [path, query] = clean.split('?')
+    const trimmed = link.trim()
+    const NOOK_PREFIX = 'nook://drive-share?'
 
-    if (!query) return null
-
-    const params = new URLSearchParams(query)
+    if (!trimmed.startsWith(NOOK_PREFIX)) return null
+    const params = new URLSearchParams(trimmed.slice(NOOK_PREFIX.length))
+    const feedTopic = params.get('topic')
+    const feedOwner = params.get('owner')
     const actPublisher = params.get('publisher')
 
-    if (!actPublisher) return null
+    if (!feedTopic || !feedOwner || !actPublisher) return null
 
-    // Feed-based: swarm://feed?topic=...&owner=...&publisher=...
-    if (path === 'feed') {
-      const feedTopic = params.get('topic')
-      const feedOwner = params.get('owner')
+    const addr = params.get('addr')
+    const wpub = params.get('wpub')
+    const bpub = params.get('bpub')
+    const name = params.get('name') ?? undefined
+    const sender = addr && wpub && bpub ? { addr, walletPublicKey: wpub, beePublicKey: bpub, name } : undefined
 
-      if (!feedTopic || !feedOwner) return null
-
-      return { type: 'feed', feedTopic, feedOwner, actPublisher }
-    }
-
-    // Legacy snapshot: swarm://reference?publisher=...&history=...
-    const actHistoryRef = params.get('history')
-
-    if (!actHistoryRef || path.length < 64) return null
-
-    return { type: 'snapshot', reference: path, actPublisher, actHistoryRef }
+    return { feedTopic, feedOwner, actPublisher, sender }
   } catch {
     return null
   }
+}
+
+/** Build a share link. Throws if any required field is missing. */
+export function buildShareLink(args: {
+  feedTopic: string
+  feedOwner: string
+  actPublisher: string
+  sender: SenderContactInfo
+}): string {
+  const params = new URLSearchParams({
+    topic: args.feedTopic,
+    owner: args.feedOwner,
+    publisher: args.actPublisher,
+    addr: args.sender.addr,
+    wpub: args.sender.walletPublicKey,
+    bpub: args.sender.beePublicKey,
+  })
+
+  if (args.sender.name) params.set('name', args.sender.name)
+
+  return `nook://drive-share?${params.toString()}`
 }
 
 export function useSharedDrives() {

--- a/ui/src/notify/invitations.ts
+++ b/ui/src/notify/invitations.ts
@@ -1,0 +1,83 @@
+/**
+ * Pending invitations — on-chain wake-up notifications received from senders
+ * who aren't yet in our contact list. Surfaced in the Messages inbox so the
+ * user can accept (add as contact) and pick up the real mailbox message that
+ * follows.
+ *
+ * Per-origin localStorage like everything else under #47.
+ */
+
+export interface Invitation {
+  /** Sender's lowercased ETH address */
+  senderAddr: string
+  /** Block number of the on-chain notification event (oldest seen) */
+  blockNumber: number
+  /** Unix ms when first observed locally */
+  ts: number
+  /** True after user adds the sender as a contact */
+  processed: boolean
+}
+
+const INVITATIONS_KEY = 'nook-invitations-v1'
+const CURSOR_PREFIX = 'nook-registry-cursor:'
+
+function load<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+
+    return raw ? (JSON.parse(raw) as T) : fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function loadInvitations(): Invitation[] {
+  return load<Invitation[]>(INVITATIONS_KEY, [])
+}
+
+export function saveInvitations(invs: Invitation[]): void {
+  localStorage.setItem(INVITATIONS_KEY, JSON.stringify(invs))
+}
+
+/**
+ * Insert an invitation if not already present (deduped by senderAddr).
+ * Keeps the OLDEST blockNumber when the same sender pings multiple times.
+ */
+export function addInvitation(invs: Invitation[], senderAddr: string, blockNumber: number): Invitation[] {
+  const id = senderAddr.toLowerCase()
+  const existing = invs.find(i => i.senderAddr === id)
+
+  if (existing) return invs
+  const next: Invitation = { senderAddr: id, blockNumber, ts: Date.now(), processed: false }
+  const updated = [...invs, next]
+
+  saveInvitations(updated)
+
+  return updated
+}
+
+/** Mark an invitation processed once user adds the sender as contact. */
+export function markInvitationProcessed(invs: Invitation[], senderAddr: string): Invitation[] {
+  const id = senderAddr.toLowerCase()
+  const updated = invs.map(i => (i.senderAddr === id ? { ...i, processed: true } : i))
+
+  saveInvitations(updated)
+
+  return updated
+}
+
+/** Pending = not processed yet. */
+export function pendingInvitations(invs: Invitation[]): Invitation[] {
+  return invs.filter(i => !i.processed)
+}
+
+/** Per-identity registry-poll cursor (block number we polled up to). */
+export function getRegistryCursor(myAddr: string): number {
+  const raw = localStorage.getItem(CURSOR_PREFIX + myAddr.toLowerCase())
+
+  return raw ? Number(raw) : 0
+}
+
+export function setRegistryCursor(myAddr: string, block: number): void {
+  localStorage.setItem(CURSOR_PREFIX + myAddr.toLowerCase(), String(block))
+}

--- a/ui/src/notify/messages.ts
+++ b/ui/src/notify/messages.ts
@@ -153,6 +153,17 @@ export function unreadCount(thread: StoredMessage[] | undefined, cursor: number 
   return thread.filter(m => m.direction === 'received' && m.ts > c).length
 }
 
+/** Total unread across all conversations. */
+export function totalUnread(threads: ThreadMap, cursors: ReadCursorMap): number {
+  let total = 0
+
+  for (const [counterparty, msgs] of Object.entries(threads)) {
+    total += unreadCount(msgs, cursors[counterparty])
+  }
+
+  return total
+}
+
 /** Mark a conversation read up to `ts` (defaults to now). */
 export function markRead(cursors: ReadCursorMap, counterparty: string, ts = Date.now()): ReadCursorMap {
   const updated = { ...cursors, [counterparty.toLowerCase()]: ts }

--- a/ui/src/notify/messages.ts
+++ b/ui/src/notify/messages.ts
@@ -22,6 +22,18 @@ export interface StoredMessage {
   /** Plain text */
   body: string
   direction: 'sent' | 'received'
+  /** Optional message kind. Default 'message'. 'drive-share' renders as a card. */
+  kind?: 'message' | 'drive-share'
+  /** Drive-share fields — only present when kind === 'drive-share' */
+  driveShareLink?: string
+  driveName?: string
+  fileCount?: number
+}
+
+export interface DriveShareExtras {
+  driveShareLink: string
+  driveName: string
+  fileCount: number
 }
 
 const MESSAGES_KEY = 'nook-messages-v1'
@@ -60,10 +72,46 @@ function makeId(ts: number, direction: StoredMessage['direction'], body: string)
   return `${ts}-${direction}-${body.slice(0, 32)}`
 }
 
-/** Append a sent message to a thread. */
+/** Append a sent text message to a thread. */
 export function appendSent(threads: ThreadMap, counterparty: string, body: string, ts = Date.now()): ThreadMap {
   const key = counterparty.toLowerCase()
-  const msg: StoredMessage = { id: makeId(ts, 'sent', body), counterparty: key, ts, body, direction: 'sent' }
+  const msg: StoredMessage = {
+    id: makeId(ts, 'sent', body),
+    counterparty: key,
+    ts,
+    body,
+    direction: 'sent',
+    kind: 'message',
+  }
+  const updated: ThreadMap = { ...threads, [key]: [...(threads[key] ?? []), msg] }
+
+  saveThreads(updated)
+
+  return updated
+}
+
+/** Append a sent drive-share message to a thread. */
+export function appendSentDriveShare(
+  threads: ThreadMap,
+  counterparty: string,
+  extras: DriveShareExtras,
+  ts = Date.now(),
+): ThreadMap {
+  const key = counterparty.toLowerCase()
+  // Keep `body` as plain text so older renderers (and the conversation preview)
+  // still show something readable if the kind tag gets lost.
+  const body = `Shared "${extras.driveName}" (${extras.fileCount} file${extras.fileCount === 1 ? '' : 's'})`
+  const msg: StoredMessage = {
+    id: makeId(ts, 'sent', body),
+    counterparty: key,
+    ts,
+    body,
+    direction: 'sent',
+    kind: 'drive-share',
+    driveShareLink: extras.driveShareLink,
+    driveName: extras.driveName,
+    fileCount: extras.fileCount,
+  }
   const updated: ThreadMap = { ...threads, [key]: [...(threads[key] ?? []), msg] }
 
   saveThreads(updated)
@@ -84,6 +132,10 @@ export function mergeReceived(threads: ThreadMap, counterparty: string, received
     ts: m.ts,
     body: m.body,
     direction: 'received',
+    kind: m.type === 'drive-share' ? 'drive-share' : 'message',
+    driveShareLink: m.driveShareLink,
+    driveName: m.driveName,
+    fileCount: m.fileCount,
   }))
   const merged = [...existingSent, ...incoming].sort((a, b) => a.ts - b.ts)
   const updated: ThreadMap = { ...threads, [key]: merged }

--- a/ui/src/notify/types.ts
+++ b/ui/src/notify/types.ts
@@ -21,7 +21,7 @@ export interface NookContact {
   /** ENS name if known */
   ensName?: string
   /** How this contact was added — for UX badges + future reasoning */
-  source: 'identity-feed' | 'share-link'
+  source: 'identity-feed' | 'share-link' | 'drive-share'
   /** Unix timestamp ms */
   addedAt: number
 }


### PR DESCRIPTION
## Summary

End-to-end rewrite of the drive-share flow so that sharing a drive also bundles the sender's contact info into the link AND fires both off-chain (mailbox) and on-chain (Gnosis registry) notifications. The recipient sees invitations in the Messages inbox even when not yet a contact, can peek the sender's mailbox feed before accepting, and gets a drive-share card with one-click import once accepted.

Closes #41 (share-link contact info), #62 (sender on-chain wake-up), #63 (recipient invitation polling/UI), #66 (mailbox peek).

## What's in here

### Drive share link

- New format: `nook://drive-share?topic=…&owner=…&publisher=…&addr=…&wpub=…&name=…`
- Pre-release schema break — legacy `swarm://feed?…` no longer parses
- Includes sender's Nook address + wallet pubkey so recipient can add as contact in one step (`bpub` deduped — equal to `publisher`)

### ShareModal (sender)

- Grantee picker reads from main contact list (`nook-contacts-v2`)
- Optional **Your name** field, surfaces in link + mailbox subject
- Accept Nook address (0x… 42 chars) OR raw bpub in the sharing-key field — auto-resolves via identity feed
- New **Send notification** batch button — typed `drive-share` mailbox messages to all eligible contact-grantees (per-row sent / failed / not in contacts pills)
- Optional **Also send on-chain wake-up** checkbox — fires `registry.sendNotification` on Gnosis (~0.001 xDAI) for recipients not yet your contact

### AddSharedDriveModal (recipient)

- Parses new format, shows **Also add sender as contact** checkbox + nickname (pre-filled from sender's bundled name)
- Saves contact with `source: 'drive-share'`

### Messages inbox (recipient)

- Drive-share messages render as bordered cards with drive icon, name, file count, and **Add drive** button (pre-fills AddSharedDriveModal)
- Background inbox polling moved to Layout-level hook so messages arrive even when Messages page isn't open
- Unread badge on Messages sidebar entry (includes pending invitations)
- **On-chain invitations** appear at top of conversations list with Mail icon. Selecting one triggers a peek (identity.resolve + mailbox.readMessages with a temp Contact) so user sees who's reaching out + what they sent BEFORE accepting. Nickname pre-filled from sender's bundled name. Accepting resolves identity, saves contact, and switches to the new conversation.

### Background polling

- New `useInboxPolling` (mailbox feeds, every 30s)
- New `useRegistryPolling` (Gnosis registry events, every 2min, per-identity cursor in localStorage)
- Both wired into Layout

### Storage extensions

- `StoredMessage` gains optional `kind`/`driveShareLink`/`driveName`/`fileCount`
- New `notify/invitations.ts` with per-identity poll cursor

## How to test (two parties)

1. Both pull `feat/drive-share-with-contact`, install, restart, open `localhost:3002`
2. Both derive Nook key (Contacts page)
3. **A → B with B in contacts** (already-connected case): A opens encrypted drive → Share → grant B → optionally **Your name** → Send notification (no on-chain). B's Messages tab shows drive-share card → Add drive
4. **A → B without B in contacts** (first-contact case): B removes A → A grants B (paste B's Nook addr in sharing key field — auto-resolves) → Send notification + tick on-chain wake-up. Within ~3min, B sees invitation in Messages sidebar with Mail icon. Click → preview shows A's name + drive-share message. Type nickname (pre-filled) → Add as contact → drive-share card appears within ~30s

## Known limitation

Old files in a drive aren't downloadable by new grantees — Bee ACT chain is forward-only, so grants apply to content uploaded after the grant. Workaround for now: re-upload old files. Real fix tracked separately.

## Out of scope (follow-ups)

- Per-file regrant for retroactive access (above)
- Stewardship re-push to improve chunk reachability
- ENS-aware sender names in invitations