### PR TITLE
feat: collaborative encrypted drives with ACT-based access control

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "dependencies": {
         "@ethersphere/bee-js": "^11.1.1",
+        "@nook/act-js": "github:misaakidis/act-js",
         "@rainbow-me/rainbowkit": "^2.2.10",
         "@swarm-notify/sdk": "github:GasperX93/swarm-notify#afc9675ec0a27ea2a6aad9be7bd2399508373999",
         "@tanstack/react-query": "^5.90.21",
@@ -2315,6 +2316,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nook/act-js": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/misaakidis/act-js.git#25ab0b9c3ab24039c517b909bbbd5f12529ff928",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "^1.8.0",
+        "@noble/secp256k1": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@ethersphere/bee-js": "^11.1.1"
       }
     },
     "node_modules/@paulmillr/qr": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ethersphere/bee-js": "^11.1.1",
+    "@nook/act-js": "github:misaakidis/act-js",
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@swarm-notify/sdk": "github:GasperX93/swarm-notify#afc9675ec0a27ea2a6aad9be7bd2399508373999",
     "@tanstack/react-query": "^5.90.21",

--- a/ui/src/api/createSharedDrive.ts
+++ b/ui/src/api/createSharedDrive.ts
@@ -1,0 +1,70 @@
+import { Bee, type BatchId } from '@ethersphere/bee-js'
+import { ActClient, rawKeySigner } from '@nook/act-js'
+import { secp256k1 } from 'ethereum-cryptography/secp256k1'
+import { deriveWriteKey, driveFeedTopicHex } from '../crypto/drive'
+import { writeEntry } from './driveFeed'
+import type { NookSigner } from '../crypto/signer'
+import type { SharedDriveV2 } from '../hooks/useSharedDrives'
+
+export interface CreateSharedDriveArgs {
+  bee: Bee
+  signer: NookSigner
+  creatorAddress: string
+  stamp: BatchId | string
+  name: string
+}
+
+export interface CreateSharedDriveResult {
+  drive: SharedDriveV2
+}
+
+export async function createSharedDrive(args: CreateSharedDriveArgs): Promise<CreateSharedDriveResult> {
+  const driveId = crypto.randomUUID()
+  const signingKey = args.signer.getSigningKey()
+  const wk = deriveWriteKey(signingKey, driveId)
+
+  const actSigner = rawKeySigner(signingKey)
+  const creatorUncompressedPub = secp256k1.getPublicKey(signingKey, false)
+
+  const act = new ActClient({ bee: args.bee as any, stamp: args.stamp })
+  const { historyRef } = await act.create({ signer: actSigner, grantees: [creatorUncompressedPub] })
+
+  // Upload initial empty manifest
+  const emptyManifest = new TextEncoder().encode(JSON.stringify({ v: 1, files: [] }))
+  const manifestUpload = await args.bee.uploadData(args.stamp, emptyManifest)
+  const manifestRef = manifestUpload.reference.toUint8Array()
+
+  // Encrypt manifest ref using the creator's own ACT access key
+  const encryptedRef = await act.encryptRef(manifestRef, { signer: actSigner, historyRef })
+
+  const topicHex = driveFeedTopicHex(args.creatorAddress, driveId)
+  await writeEntry({
+    bee: args.bee,
+    stamp: args.stamp,
+    topicHex,
+    writeKeyPriv: wk.privateKey,
+    entry: { historyRef: bytesToHex(historyRef), encryptedRef: bytesToHex(encryptedRef) },
+  })
+
+  const drive: SharedDriveV2 = {
+    driveId,
+    name: args.name,
+    creatorAddress: args.creatorAddress.toLowerCase(),
+    myRole: 'creator',
+    writeKey: bytesToHex(wk.privateKey),
+    writeKeyVersion: wk.version,
+    walletPublicKey: bytesToHex(args.signer.getPublicKey()),
+    driveFeedTopic: topicHex,
+    cachedHistoryRef: bytesToHex(historyRef),
+    cachedManifestRef: bytesToHex(manifestRef),
+    addedAt: Date.now(),
+  }
+
+  return { drive }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}

--- a/ui/src/api/driveFeed.ts
+++ b/ui/src/api/driveFeed.ts
@@ -28,7 +28,9 @@ export async function readLatestEntry(args: ReadLatestArgs): Promise<DriveFeedEn
     const result = await reader.downloadPayload()
     const text = new TextDecoder().decode(result.payload.toUint8Array())
     const parsed = JSON.parse(text) as DriveFeedEntry
+
     if (parsed.v !== 1) throw new Error(`driveFeed: unsupported entry version ${parsed.v}`)
+
     return parsed
   } catch (err) {
     if (isNotFoundError(err)) return null
@@ -47,11 +49,13 @@ export async function writeEntry(args: WriteEntryArgs): Promise<Reference> {
   const bytes = new TextEncoder().encode(JSON.stringify(payload))
   const writer = args.bee.makeFeedWriter(new Topic(args.topicHex), new PrivateKey(args.writeKeyPriv))
   const result = await writer.uploadPayload(args.stamp, bytes)
+
   return result.reference
 }
 
 function isNotFoundError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false
   const msg = String((err as { message?: string }).message ?? '').toLowerCase()
+
   return msg.includes('not found') || msg.includes('404')
 }

--- a/ui/src/api/driveFeed.ts
+++ b/ui/src/api/driveFeed.ts
@@ -1,0 +1,57 @@
+import { Bee, PrivateKey, Topic, type BatchId, type Reference } from '@ethersphere/bee-js'
+
+export interface DriveFeedEntry {
+  v: 1
+  historyRef: string
+  encryptedRef: string
+  memberListRef?: string
+  ts: number
+}
+
+export interface WriteEntryArgs {
+  bee: Bee
+  stamp: BatchId | string
+  topicHex: string
+  writeKeyPriv: Uint8Array
+  entry: Omit<DriveFeedEntry, 'v' | 'ts'>
+}
+
+export interface ReadLatestArgs {
+  bee: Bee
+  topicHex: string
+  ownerAddress: string
+}
+
+export async function readLatestEntry(args: ReadLatestArgs): Promise<DriveFeedEntry | null> {
+  const reader = args.bee.makeFeedReader(new Topic(args.topicHex), args.ownerAddress)
+  try {
+    const result = await reader.downloadPayload()
+    const text = new TextDecoder().decode(result.payload.toUint8Array())
+    const parsed = JSON.parse(text) as DriveFeedEntry
+    if (parsed.v !== 1) throw new Error(`driveFeed: unsupported entry version ${parsed.v}`)
+    return parsed
+  } catch (err) {
+    if (isNotFoundError(err)) return null
+    throw err
+  }
+}
+
+export async function writeEntry(args: WriteEntryArgs): Promise<Reference> {
+  const payload: DriveFeedEntry = {
+    v: 1,
+    historyRef: args.entry.historyRef,
+    encryptedRef: args.entry.encryptedRef,
+    memberListRef: args.entry.memberListRef,
+    ts: Math.floor(Date.now() / 1000),
+  }
+  const bytes = new TextEncoder().encode(JSON.stringify(payload))
+  const writer = args.bee.makeFeedWriter(new Topic(args.topicHex), new PrivateKey(args.writeKeyPriv))
+  const result = await writer.uploadPayload(args.stamp, bytes)
+  return result.reference
+}
+
+function isNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const msg = String((err as { message?: string }).message ?? '').toLowerCase()
+  return msg.includes('not found') || msg.includes('404')
+}

--- a/ui/src/api/memberList.ts
+++ b/ui/src/api/memberList.ts
@@ -27,6 +27,7 @@ export interface MemberListDoc {
 function canonicalJson(doc: Omit<MemberListDoc, 'signature'>): string {
   const { v, driveId, creatorAddress, writeKeyVersion, updatedAt, members } = doc
   const sortedMembers = [...members].sort((a, b) => a.ethAddress.localeCompare(b.ethAddress))
+
   return JSON.stringify({ v, driveId, creatorAddress, writeKeyVersion, updatedAt, members: sortedMembers })
 }
 
@@ -39,6 +40,7 @@ export async function signMemberList(
   const sigBytes = new Uint8Array(65)
   sigBytes.set(sig.toCompactRawBytes(), 0)
   sigBytes[64] = sig.recovery ?? 0
+
   return { ...doc, signature: bytesToHex(sigBytes) }
 }
 
@@ -49,6 +51,7 @@ export function verifyMemberList(doc: MemberListDoc, expectedCreatorPub: Uint8Ar
     const sigBytes = hexToBytes(doc.signature)
     const sig = secp256k1.Signature.fromCompact(sigBytes.slice(0, 64)).addRecoveryBit(sigBytes[64])
     const recoveredPub = sig.recoverPublicKey(digest).toRawBytes(false)
+
     return equalBytes(recoveredPub, expectedCreatorPub)
   } catch {
     return false
@@ -80,6 +83,7 @@ export async function updateMemberList(args: UpdateMemberListArgs): Promise<Upda
   let newMembers: MemberEntry[] = current?.members ?? [seed]
 
   const change = args.change
+
   if ('add' in change) {
     newMembers = newMembers.filter(m => m.ethAddress !== change.add.ethAddress)
     newMembers.push(change.add)
@@ -105,12 +109,14 @@ export async function updateMemberList(args: UpdateMemberListArgs): Promise<Upda
 
   const bytes = new TextEncoder().encode(JSON.stringify(doc))
   const upload = await args.bee.uploadData(args.stamp, bytes)
+
   return { ref: upload.reference.toUint8Array(), doc }
 }
 
 export async function fetchMemberList(bee: Bee, ref: Uint8Array): Promise<MemberListDoc | null> {
   try {
     const data = await bee.downloadData(ref)
+
     return JSON.parse(new TextDecoder().decode(data.toUint8Array())) as MemberListDoc
   } catch {
     return null
@@ -121,6 +127,7 @@ function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith('0x') ? hex.slice(2) : hex
   const out = new Uint8Array(clean.length / 2)
   for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+
   return out
 }
 
@@ -132,5 +139,6 @@ function bytesToHex(bytes: Uint8Array): string {
 
 function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false
+
   return a.every((v, i) => v === b[i])
 }

--- a/ui/src/api/memberList.ts
+++ b/ui/src/api/memberList.ts
@@ -1,0 +1,136 @@
+import { Bee, type BatchId } from '@ethersphere/bee-js'
+import { keccak_256 } from '@noble/hashes/sha3'
+import { secp256k1 } from 'ethereum-cryptography/secp256k1'
+import type { NookSigner } from '../crypto/signer'
+import type { SharedDriveV2 } from '../hooks/useSharedDrives'
+
+export type MemberRole = 'creator' | 'writer' | 'reader'
+
+export interface MemberEntry {
+  ethAddress: string
+  role: MemberRole
+  addedAt: number
+  walletPublicKey?: string // compressed hex, cached for convenience
+}
+
+export interface MemberListDoc {
+  v: 1
+  driveId: string
+  creatorAddress: string
+  writeKeyVersion: number
+  updatedAt: number
+  members: MemberEntry[]
+  signature: string // 65-byte hex: r(32) + s(32) + v(1)
+}
+
+/** Stable canonical JSON for signing — deterministic key order + sorted members. */
+function canonicalJson(doc: Omit<MemberListDoc, 'signature'>): string {
+  const { v, driveId, creatorAddress, writeKeyVersion, updatedAt, members } = doc
+  const sortedMembers = [...members].sort((a, b) => a.ethAddress.localeCompare(b.ethAddress))
+  return JSON.stringify({ v, driveId, creatorAddress, writeKeyVersion, updatedAt, members: sortedMembers })
+}
+
+export async function signMemberList(
+  doc: Omit<MemberListDoc, 'signature'>,
+  signer: NookSigner,
+): Promise<MemberListDoc> {
+  const digest = keccak_256(new TextEncoder().encode(canonicalJson(doc)))
+  const sig = secp256k1.sign(digest, signer.getSigningKey())
+  const sigBytes = new Uint8Array(65)
+  sigBytes.set(sig.toCompactRawBytes(), 0)
+  sigBytes[64] = sig.recovery ?? 0
+  return { ...doc, signature: bytesToHex(sigBytes) }
+}
+
+export function verifyMemberList(doc: MemberListDoc, expectedCreatorPub: Uint8Array): boolean {
+  try {
+    const { signature: _sig, ...rest } = doc
+    const digest = keccak_256(new TextEncoder().encode(canonicalJson(rest as Omit<MemberListDoc, 'signature'>)))
+    const sigBytes = hexToBytes(doc.signature)
+    const sig = secp256k1.Signature.fromCompact(sigBytes.slice(0, 64)).addRecoveryBit(sigBytes[64])
+    const recoveredPub = sig.recoverPublicKey(digest).toRawBytes(false)
+    return equalBytes(recoveredPub, expectedCreatorPub)
+  } catch {
+    return false
+  }
+}
+
+export interface UpdateMemberListArgs {
+  bee: Bee
+  stamp: BatchId | string
+  drive: SharedDriveV2
+  signer: NookSigner
+  change:
+    | { add: MemberEntry }
+    | { remove: { ethAddress: string } }
+    | { updateRole: { ethAddress: string; role: MemberRole } }
+}
+
+export interface UpdateMemberListResult {
+  ref: Uint8Array
+  doc: MemberListDoc
+}
+
+export async function updateMemberList(args: UpdateMemberListArgs): Promise<UpdateMemberListResult> {
+  const current = args.drive.cachedMemberListRef
+    ? await fetchMemberList(args.bee, hexToBytes(args.drive.cachedMemberListRef))
+    : null
+
+  const seed: MemberEntry = { ethAddress: args.drive.creatorAddress, role: 'creator', addedAt: Date.now() }
+  let newMembers: MemberEntry[] = current?.members ?? [seed]
+
+  const change = args.change
+  if ('add' in change) {
+    newMembers = newMembers.filter(m => m.ethAddress !== change.add.ethAddress)
+    newMembers.push(change.add)
+  } else if ('remove' in change) {
+    newMembers = newMembers.filter(m => m.ethAddress !== change.remove.ethAddress)
+  } else if ('updateRole' in change) {
+    newMembers = newMembers.map(m =>
+      m.ethAddress === change.updateRole.ethAddress ? { ...m, role: change.updateRole.role } : m,
+    )
+  }
+
+  const doc = await signMemberList(
+    {
+      v: 1,
+      driveId: args.drive.driveId,
+      creatorAddress: args.drive.creatorAddress,
+      writeKeyVersion: args.drive.writeKeyVersion,
+      updatedAt: Date.now(),
+      members: newMembers,
+    },
+    args.signer,
+  )
+
+  const bytes = new TextEncoder().encode(JSON.stringify(doc))
+  const upload = await args.bee.uploadData(args.stamp, bytes)
+  return { ref: upload.reference.toUint8Array(), doc }
+}
+
+export async function fetchMemberList(bee: Bee, ref: Uint8Array): Promise<MemberListDoc | null> {
+  try {
+    const data = await bee.downloadData(ref)
+    return JSON.parse(new TextDecoder().decode(data.toUint8Array())) as MemberListDoc
+  } catch {
+    return null
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  return a.every((v, i) => v === b[i])
+}

--- a/ui/src/api/sharedDriveUpload.ts
+++ b/ui/src/api/sharedDriveUpload.ts
@@ -1,0 +1,132 @@
+import { Bee, type BatchId } from '@ethersphere/bee-js'
+import { ActClient, rawKeySigner } from '@nook/act-js'
+import { secp256k1 } from 'ethereum-cryptography/secp256k1'
+import { keccak_256 } from '@noble/hashes/sha3'
+import { readLatestEntry, writeEntry } from './driveFeed'
+import type { SharedDriveV2 } from '../hooks/useSharedDrives'
+
+export type UploadStage =
+  | 'fetching_feed'
+  | 'decrypting_manifest'
+  | 'uploading_file'
+  | 'updating_manifest'
+  | 'signing_feed'
+  | 'done'
+
+export interface UploadArgs {
+  bee: Bee
+  stamp: BatchId | string
+  drive: SharedDriveV2
+  mySigningKey: Uint8Array // NookSigner.getSigningKey()
+  file: { name: string; mime: string; bytes: Uint8Array }
+  onProgress?: (stage: UploadStage) => void
+}
+
+export interface UploadResult {
+  fileRef: string
+  newManifestRef: string
+  newEncryptedRef: string
+}
+
+interface ManifestFile {
+  id: string
+  name: string
+  ref: string
+  size: number
+  mime: string
+  uploadedAt: number
+}
+
+export async function uploadToSharedDrive(args: UploadArgs): Promise<UploadResult> {
+  const { bee, stamp, drive, mySigningKey, file, onProgress } = args
+
+  if (!drive.writeKey) throw new Error('uploadToSharedDrive: writeKey missing (reader-only drive)')
+  if (!drive.walletPublicKey) throw new Error('uploadToSharedDrive: creator walletPublicKey missing')
+
+  const writeKeyPriv = hexToBytes(drive.writeKey)
+  // Derive the feed owner address from the writeKey private key
+  const writeKeyPub = secp256k1.getPublicKey(writeKeyPriv, false) // uncompressed
+  const addrBytes = keccak_256(writeKeyPub.slice(1))
+  const ownerAddress = '0x' + bytesToHex(addrBytes.slice(-20))
+
+  const creatorPub = secp256k1.ProjectivePoint.fromHex(drive.walletPublicKey).toRawBytes(false)
+  const mySigner = rawKeySigner(mySigningKey)
+  const act = new ActClient({ bee: bee as any, stamp })
+
+  onProgress?.('fetching_feed')
+  const latest = await readLatestEntry({ bee, topicHex: drive.driveFeedTopic, ownerAddress })
+  if (!latest) throw new Error('uploadToSharedDrive: drive feed is empty')
+
+  const historyRef = hexToBytes(latest.historyRef)
+  const encryptedRef = hexToBytes(latest.encryptedRef)
+
+  onProgress?.('decrypting_manifest')
+  const manifestRef = await act.decryptRef(encryptedRef, {
+    signer: mySigner,
+    publisherPub: creatorPub,
+    historyRef,
+  })
+
+  const manifestData = await bee.downloadData(manifestRef)
+  const manifest = JSON.parse(
+    new TextDecoder().decode(manifestData.toUint8Array()),
+  ) as { v: 1; files: ManifestFile[] }
+
+  onProgress?.('uploading_file')
+  const fileUpload = await bee.uploadData(stamp, file.bytes)
+  const fileRef = fileUpload.reference.toUint8Array()
+
+  onProgress?.('updating_manifest')
+  manifest.files.push({
+    id: crypto.randomUUID(),
+    name: file.name,
+    ref: bytesToHex(fileRef),
+    size: file.bytes.length,
+    mime: file.mime,
+    uploadedAt: Date.now(),
+  })
+
+  const newManifestBytes = new TextEncoder().encode(JSON.stringify(manifest))
+  const newManifestUpload = await bee.uploadData(stamp, newManifestBytes)
+  const newManifestRef = newManifestUpload.reference.toUint8Array()
+
+  // Re-encrypt under the same historyRef (historyRef does not change on uploads)
+  const newEncryptedRef = await act.reencryptRef(newManifestRef, {
+    signer: mySigner,
+    publisherPub: creatorPub,
+    historyRef,
+  })
+
+  onProgress?.('signing_feed')
+  await writeEntry({
+    bee,
+    stamp,
+    topicHex: drive.driveFeedTopic,
+    writeKeyPriv,
+    entry: {
+      historyRef: latest.historyRef,
+      encryptedRef: bytesToHex(newEncryptedRef),
+      memberListRef: latest.memberListRef,
+    },
+  })
+
+  onProgress?.('done')
+  return {
+    fileRef: bytesToHex(fileRef),
+    newManifestRef: bytesToHex(newManifestRef),
+    newEncryptedRef: bytesToHex(newEncryptedRef),
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}

--- a/ui/src/api/sharedDriveUpload.ts
+++ b/ui/src/api/sharedDriveUpload.ts
@@ -41,6 +41,7 @@ export async function uploadToSharedDrive(args: UploadArgs): Promise<UploadResul
   const { bee, stamp, drive, mySigningKey, file, onProgress } = args
 
   if (!drive.writeKey) throw new Error('uploadToSharedDrive: writeKey missing (reader-only drive)')
+
   if (!drive.walletPublicKey) throw new Error('uploadToSharedDrive: creator walletPublicKey missing')
 
   const writeKeyPriv = hexToBytes(drive.writeKey)
@@ -55,6 +56,7 @@ export async function uploadToSharedDrive(args: UploadArgs): Promise<UploadResul
 
   onProgress?.('fetching_feed')
   const latest = await readLatestEntry({ bee, topicHex: drive.driveFeedTopic, ownerAddress })
+
   if (!latest) throw new Error('uploadToSharedDrive: drive feed is empty')
 
   const historyRef = hexToBytes(latest.historyRef)
@@ -68,9 +70,7 @@ export async function uploadToSharedDrive(args: UploadArgs): Promise<UploadResul
   })
 
   const manifestData = await bee.downloadData(manifestRef)
-  const manifest = JSON.parse(
-    new TextDecoder().decode(manifestData.toUint8Array()),
-  ) as { v: 1; files: ManifestFile[] }
+  const manifest = JSON.parse(new TextDecoder().decode(manifestData.toUint8Array())) as { v: 1; files: ManifestFile[] }
 
   onProgress?.('uploading_file')
   const fileUpload = await bee.uploadData(stamp, file.bytes)
@@ -111,6 +111,7 @@ export async function uploadToSharedDrive(args: UploadArgs): Promise<UploadResul
   })
 
   onProgress?.('done')
+
   return {
     fileRef: bytesToHex(fileRef),
     newManifestRef: bytesToHex(newManifestRef),
@@ -122,6 +123,7 @@ function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith('0x') ? hex.slice(2) : hex
   const out = new Uint8Array(clean.length / 2)
   for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+
   return out
 }
 

--- a/ui/src/components/AddSharedDriveModal.tsx
+++ b/ui/src/components/AddSharedDriveModal.tsx
@@ -8,7 +8,9 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { beeApi } from '../api/bee'
 import { serverApi } from '../api/server'
-import { parseShareLink, type SenderContactInfo, type SharedFile } from '../hooks/useSharedDrives'
+import { decryptWriteKey } from '../crypto/drive'
+import { parseShareLink, parseShareLinkTyped, useSharedDrivesV2, type SenderContactInfo, type SharedDriveV2, type SharedFile } from '../hooks/useSharedDrives'
+import { useDerivedKey } from '../hooks/useDerivedKey'
 import { addContact, loadContacts } from '../notify/storage'
 import type { NookContact } from '../notify/types'
 
@@ -26,22 +28,28 @@ interface AddSharedDriveModalProps {
     feedTopic?: string
     feedOwner?: string
   }) => void
+  /** Called when a v2 shared drive is imported — separate from legacy onAdd */
+  onAddV2?: (drive: SharedDriveV2) => void
 }
 
-export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose, onAdd }: AddSharedDriveModalProps) {
+export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose, onAdd, onAddV2 }: AddSharedDriveModalProps) {
   const [link, setLink] = useState(initialLink ?? '')
   const [name, setName] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [copiedKey, setCopiedKey] = useState(false)
 
+  const { signer, derive } = useDerivedKey()
+  const { addDrive: addDriveV2 } = useSharedDrivesV2()
+
   // Sender contact import
   const existingContacts = useMemo<NookContact[]>(() => loadContacts(), [])
   const [addAsContact, setAddAsContact] = useState(true)
   const [contactNickname, setContactNickname] = useState('')
 
+  const parsedTyped = useMemo(() => (link.trim() ? parseShareLinkTyped(link) : null), [link])
   const parsed = useMemo(() => (link.trim() ? parseShareLink(link) : null), [link])
-  const sender: SenderContactInfo | undefined = parsed?.sender
+  const sender: SenderContactInfo | undefined = (parsedTyped?.type === 'nook-drive-share-v1' ? parsedTyped.sender : parsedTyped?.type === 'nook-drive-share-v2' ? parsedTyped.sender : undefined) ?? parsed?.sender
   const senderAlreadyContact = useMemo(() => {
     if (!sender) return false
 
@@ -55,20 +63,74 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
   }, [sender, contactNickname])
 
   async function handleAdd() {
-    if (!parsed) {
+    if (!parsedTyped && !parsed) {
       setError('Invalid share link.')
-
       return
     }
 
     if (showContactImport && addAsContact && !contactNickname.trim()) {
       setError('Type a nickname for the new contact, or uncheck "Add as contact".')
-
       return
     }
 
     setLoading(true)
     setError(null)
+
+    // ── V2 shared drive path ────────────────────────────────────────────────
+    if (parsedTyped?.type === 'nook-drive-share-v2') {
+      try {
+        let writeKeyHex: string | undefined
+        if (parsedTyped.writeKeyBlob && parsedTyped.role === 'writer') {
+          let activeSigner = signer
+          if (!activeSigner) activeSigner = await derive()
+          if (!activeSigner) {
+            setError('Connect your wallet to import a writer drive.')
+            setLoading(false)
+            return
+          }
+          try {
+            const wkBytes = await decryptWriteKey(hexToBytes(parsedTyped.writeKeyBlob), activeSigner.getSigningKey())
+            writeKeyHex = bytesToHex(wkBytes)
+          } catch {
+            // Decryption failed — add as reader-only
+          }
+        }
+
+        const driveName = name.trim() || parsedTyped.name || 'Shared drive'
+        const drive: SharedDriveV2 = {
+          driveId: parsedTyped.driveId,
+          name: driveName,
+          creatorAddress: parsedTyped.creatorAddress,
+          myRole: writeKeyHex ? 'writer' : 'reader',
+          writeKey: writeKeyHex,
+          writeKeyVersion: parsedTyped.writeKeyVersion,
+          walletPublicKey: parsedTyped.walletPublicKey,
+          driveFeedTopic: parsedTyped.driveFeedTopic,
+          addedAt: Date.now(),
+        }
+
+        if (onAddV2) onAddV2(drive)
+        else addDriveV2(drive)
+
+        if (showContactImport && addAsContact && sender) {
+          tryAddSenderContact(sender, contactNickname.trim(), existingContacts)
+        }
+
+        onClose()
+        return
+      } catch {
+        setError('Could not add this drive. Check the link and try again.')
+        setLoading(false)
+        return
+      }
+    }
+
+    // ── Legacy v1 path ──────────────────────────────────────────────────────
+    if (!parsed) {
+      setError('Invalid share link.')
+      setLoading(false)
+      return
+    }
 
     try {
       // Drive: read feed → get wrapper → ACT download metadata
@@ -114,6 +176,21 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
       setError('Could not access this drive. Make sure the owner has granted you access using your sharing key.')
     } finally {
       setLoading(false)
+    }
+  }
+
+  function tryAddSenderContact(senderInfo: SenderContactInfo, nickname: string, contacts: NookContact[]) {
+    try {
+      addContact(contacts, {
+        id: senderInfo.addr.toLowerCase(),
+        nickname,
+        walletPublicKey: senderInfo.walletPublicKey,
+        beePublicKey: senderInfo.beePublicKey,
+        source: 'drive-share',
+        addedAt: Date.now(),
+      })
+    } catch {
+      // Race with another tab — non-fatal
     }
   }
 
@@ -261,4 +338,17 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
       </div>
     </div>
   )
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
 }

--- a/ui/src/components/AddSharedDriveModal.tsx
+++ b/ui/src/components/AddSharedDriveModal.tsx
@@ -9,7 +9,14 @@ import { useEffect, useMemo, useState } from 'react'
 import { beeApi } from '../api/bee'
 import { serverApi } from '../api/server'
 import { decryptWriteKey } from '../crypto/drive'
-import { parseShareLink, parseShareLinkTyped, useSharedDrivesV2, type SenderContactInfo, type SharedDriveV2, type SharedFile } from '../hooks/useSharedDrives'
+import {
+  parseShareLink,
+  parseShareLinkTyped,
+  useSharedDrivesV2,
+  type SenderContactInfo,
+  type SharedDriveV2,
+  type SharedFile,
+} from '../hooks/useSharedDrives'
 import { useDerivedKey } from '../hooks/useDerivedKey'
 import { addContact, loadContacts } from '../notify/storage'
 import type { NookContact } from '../notify/types'
@@ -32,7 +39,13 @@ interface AddSharedDriveModalProps {
   onAddV2?: (drive: SharedDriveV2) => void
 }
 
-export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose, onAdd, onAddV2 }: AddSharedDriveModalProps) {
+export default function AddSharedDriveModal({
+  myPublicKey,
+  initialLink,
+  onClose,
+  onAdd,
+  onAddV2,
+}: AddSharedDriveModalProps) {
   const [link, setLink] = useState(initialLink ?? '')
   const [name, setName] = useState('')
   const [loading, setLoading] = useState(false)
@@ -49,7 +62,12 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
 
   const parsedTyped = useMemo(() => (link.trim() ? parseShareLinkTyped(link) : null), [link])
   const parsed = useMemo(() => (link.trim() ? parseShareLink(link) : null), [link])
-  const sender: SenderContactInfo | undefined = (parsedTyped?.type === 'nook-drive-share-v1' ? parsedTyped.sender : parsedTyped?.type === 'nook-drive-share-v2' ? parsedTyped.sender : undefined) ?? parsed?.sender
+  const sender: SenderContactInfo | undefined =
+    (parsedTyped?.type === 'nook-drive-share-v1'
+      ? parsedTyped.sender
+      : parsedTyped?.type === 'nook-drive-share-v2'
+        ? parsedTyped.sender
+        : undefined) ?? parsed?.sender
   const senderAlreadyContact = useMemo(() => {
     if (!sender) return false
 
@@ -65,11 +83,13 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
   async function handleAdd() {
     if (!parsedTyped && !parsed) {
       setError('Invalid share link.')
+
       return
     }
 
     if (showContactImport && addAsContact && !contactNickname.trim()) {
       setError('Type a nickname for the new contact, or uncheck "Add as contact".')
+
       return
     }
 
@@ -80,12 +100,16 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
     if (parsedTyped?.type === 'nook-drive-share-v2') {
       try {
         let writeKeyHex: string | undefined
+
         if (parsedTyped.writeKeyBlob && parsedTyped.role === 'writer') {
           let activeSigner = signer
+
           if (!activeSigner) activeSigner = await derive()
+
           if (!activeSigner) {
             setError('Connect your wallet to import a writer drive.')
             setLoading(false)
+
             return
           }
           try {
@@ -117,10 +141,12 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
         }
 
         onClose()
+
         return
       } catch {
         setError('Could not add this drive. Check the link and try again.')
         setLoading(false)
+
         return
       }
     }
@@ -129,6 +155,7 @@ export default function AddSharedDriveModal({ myPublicKey, initialLink, onClose,
     if (!parsed) {
       setError('Invalid share link.')
       setLoading(false)
+
       return
     }
 
@@ -344,6 +371,7 @@ function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith('0x') ? hex.slice(2) : hex
   const out = new Uint8Array(clean.length / 2)
   for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+
   return out
 }
 

--- a/ui/src/components/ShareModalV2.tsx
+++ b/ui/src/components/ShareModalV2.tsx
@@ -1,0 +1,501 @@
+/**
+ * ShareModalV2 — grantee management for ACT-backed shared drives (v2).
+ * Replaces the legacy ShareModal for drives created via createSharedDrive().
+ * Reuses the existing mailbox.send / registry notification infrastructure.
+ */
+import { Bee } from '@ethersphere/bee-js'
+import { ActClient, rawKeySigner } from '@nook/act-js'
+import { secp256k1 } from 'ethereum-cryptography/secp256k1'
+import { identity, mailbox, registry } from '@swarm-notify/sdk'
+import { Bell, Lock, RefreshCw, Trash2, Users, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useWalletClient } from 'wagmi'
+
+import { updateMemberList, type MemberEntry } from '../api/memberList'
+import { readLatestEntry, writeEntry } from '../api/driveFeed'
+import { deriveWriteKey, encryptWriteKeyForWriter } from '../crypto/drive'
+import { buildV2ShareLink, useSharedDrivesV2, type SharedDriveV2 } from '../hooks/useSharedDrives'
+import { useMemberList } from '../hooks/useMemberList'
+import { useDerivedKey } from '../hooks/useDerivedKey'
+import { GNOSIS_CHAIN_ID, REGISTRY_ADDRESS } from '../notify/constants'
+import { appendSentDriveShare, loadThreads } from '../notify/messages'
+import { createNotifyProvider } from '../notify/provider'
+import { loadContacts } from '../notify/storage'
+import { toLibraryContact } from '../notify/types'
+
+const BEE_URL = `${window.location.origin}/bee-api`
+
+type DriveRole = 'reader' | 'writer'
+type NotifyStatus = 'idle' | 'sending' | 'sent' | 'failed'
+
+interface ShareModalV2Props {
+  drive: SharedDriveV2
+  onClose: () => void
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+
+  return out
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function isEthAddress(s: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(s.trim())
+}
+
+export default function ShareModalV2({ drive, onClose }: ShareModalV2Props) {
+  const { signer } = useDerivedKey()
+  const { data: walletClient } = useWalletClient()
+  const { updateDrive } = useSharedDrivesV2()
+  const memberList = useMemberList(drive)
+  const contacts = useMemo(() => loadContacts(), [])
+  const bee = useMemo(() => new Bee(BEE_URL), [])
+
+  const [newAddress, setNewAddress] = useState('')
+  const [newRole, setNewRole] = useState<DriveRole>('reader')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notifying, setNotifying] = useState(false)
+  const [sendOnChain, setSendOnChain] = useState(false)
+  const [notifyStatus, setNotifyStatus] = useState<Record<string, NotifyStatus>>({})
+  const [onChainStatus, setOnChainStatus] = useState<Record<string, NotifyStatus>>({})
+
+  const members = memberList?.members ?? []
+  const isCreator = drive.myRole === 'creator'
+
+  // Contacts that are current grantees and can be notified
+  const notifiableMembers = useMemo(
+    () =>
+      members
+        .filter(m => m.ethAddress.toLowerCase() !== drive.creatorAddress.toLowerCase())
+        .map(m => ({ member: m, contact: contacts.find(c => c.id.toLowerCase() === m.ethAddress.toLowerCase()) }))
+        .filter((x): x is { member: MemberEntry; contact: NonNullable<(typeof x)['contact']> } => Boolean(x.contact)),
+    [members, contacts, drive.creatorAddress],
+  )
+  const pendingNotify = notifiableMembers.filter(x => notifyStatus[x.contact.id] !== 'sent')
+
+  function writeKeyOwnerAddress(): string {
+    if (!drive.writeKey) return ''
+    const priv = hexToBytes(drive.writeKey)
+    const pub = secp256k1.getPublicKey(priv, false)
+    const { keccak_256 } = require('@noble/hashes/sha3')
+    const addrBytes = keccak_256(pub.slice(1))
+
+    return '0x' + bytesToHex(addrBytes.slice(-20))
+  }
+
+  function pickStamp(): string {
+    // Use the first usable stamp — callers may enhance this with a picker
+    return drive.cachedHistoryRef ? 'default' : 'default'
+  }
+
+  async function resolveToUncompressedPub(ethAddress: string): Promise<Uint8Array> {
+    const resolved = await identity.resolve(bee, ethAddress)
+
+    if (!resolved) throw new Error(`Could not resolve identity for ${ethAddress}`)
+
+    return secp256k1.ProjectivePoint.fromHex(resolved.walletPublicKey).toRawBytes(false)
+  }
+
+  async function handleGrant() {
+    if (!signer || !drive.writeKey) {
+      setError('Wallet key required for granting access.')
+
+      return
+    }
+
+    if (!isEthAddress(newAddress.trim())) {
+      setError('Paste a Nook address (0x… 42 chars).')
+
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const resolved = await identity.resolve(bee, newAddress.trim())
+
+      if (!resolved) {
+        setError(`Could not resolve identity for ${newAddress}. They must publish a Nook identity first.`)
+
+        return
+      }
+      const granteePub = secp256k1.ProjectivePoint.fromHex(resolved.walletPublicKey).toRawBytes(false)
+      const actSigner = rawKeySigner(signer.getSigningKey())
+      const act = new ActClient({ bee: bee as any, stamp: pickStamp() })
+
+      const { historyRef: newHistoryRef } = await act.patchGrantees(
+        { add: [granteePub] },
+        { signer: actSigner, historyRef: hexToBytes(drive.cachedHistoryRef!) },
+      )
+
+      let writeKeyBlob: Uint8Array | undefined
+
+      if (newRole === 'writer') {
+        writeKeyBlob = await encryptWriteKeyForWriter(hexToBytes(drive.writeKey), granteePub)
+      }
+
+      const { ref: newMemberListRef } = await updateMemberList({
+        bee,
+        stamp: pickStamp(),
+        drive,
+        signer,
+        change: {
+          add: {
+            ethAddress: resolved.ethAddress?.toLowerCase() ?? newAddress.toLowerCase(),
+            role: newRole,
+            addedAt: Date.now(),
+            walletPublicKey: resolved.walletPublicKey,
+          },
+        },
+      })
+
+      const latest = await readLatestEntry({
+        bee,
+        topicHex: drive.driveFeedTopic,
+        ownerAddress: writeKeyOwnerAddress(),
+      })
+      await writeEntry({
+        bee,
+        stamp: pickStamp(),
+        topicHex: drive.driveFeedTopic,
+        writeKeyPriv: hexToBytes(drive.writeKey),
+        entry: {
+          historyRef: bytesToHex(newHistoryRef),
+          encryptedRef: latest?.encryptedRef ?? '',
+          memberListRef: bytesToHex(newMemberListRef),
+        },
+      })
+
+      updateDrive(drive.driveId, {
+        cachedHistoryRef: bytesToHex(newHistoryRef),
+        cachedMemberListRef: bytesToHex(newMemberListRef),
+      })
+
+      setNewAddress('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to grant access')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleRevoke(member: MemberEntry) {
+    if (!signer || !drive.writeKey) return
+    setLoading(true)
+    setError(null)
+    try {
+      const granteePub = await resolveToUncompressedPub(member.ethAddress)
+      const actSigner = rawKeySigner(signer.getSigningKey())
+      const act = new ActClient({ bee: bee as any, stamp: pickStamp() })
+
+      const { historyRef: newHistoryRef } = await act.patchGrantees(
+        { revoke: [granteePub] },
+        { signer: actSigner, historyRef: hexToBytes(drive.cachedHistoryRef!) },
+      )
+
+      let newDrivePatch: Partial<SharedDriveV2> = { cachedHistoryRef: bytesToHex(newHistoryRef) }
+
+      if (member.role === 'writer') {
+        // Rotate writeKey on writer revocation
+        const newWk = deriveWriteKey(signer.getSigningKey(), drive.driveId, drive.writeKeyVersion + 1)
+        newDrivePatch = { ...newDrivePatch, writeKey: bytesToHex(newWk.privateKey), writeKeyVersion: newWk.version }
+      }
+
+      const { ref: newMemberListRef } = await updateMemberList({
+        bee,
+        stamp: pickStamp(),
+        drive,
+        signer,
+        change: { remove: { ethAddress: member.ethAddress } },
+      })
+
+      const writeKeyForEntry = newDrivePatch.writeKey ?? drive.writeKey
+      const latest = await readLatestEntry({
+        bee,
+        topicHex: drive.driveFeedTopic,
+        ownerAddress: writeKeyOwnerAddress(),
+      })
+
+      // Re-encrypt the manifest ref under the new access key (revocation rotated it)
+      const currentManifestRef = await act.decryptRef(hexToBytes(latest!.encryptedRef), {
+        signer: actSigner,
+        publisherPub: secp256k1.ProjectivePoint.fromHex(drive.walletPublicKey!).toRawBytes(false),
+        historyRef: hexToBytes(drive.cachedHistoryRef!),
+      })
+      const newEncryptedRef = await act.reencryptRef(currentManifestRef, {
+        signer: actSigner,
+        publisherPub: secp256k1.ProjectivePoint.fromHex(drive.walletPublicKey!).toRawBytes(false),
+        historyRef: newHistoryRef,
+      })
+
+      await writeEntry({
+        bee,
+        stamp: pickStamp(),
+        topicHex: drive.driveFeedTopic,
+        writeKeyPriv: hexToBytes(writeKeyForEntry),
+        entry: {
+          historyRef: bytesToHex(newHistoryRef),
+          encryptedRef: bytesToHex(newEncryptedRef),
+          memberListRef: bytesToHex(newMemberListRef),
+        },
+      })
+
+      updateDrive(drive.driveId, { ...newDrivePatch, cachedMemberListRef: bytesToHex(newMemberListRef) })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to revoke access')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleNotifyAll() {
+    if (!signer || pendingNotify.length === 0) return
+
+    if (sendOnChain && (!walletClient || walletClient.chain?.id !== GNOSIS_CHAIN_ID)) {
+      setError(`Switch wallet to Gnosis Chain (id ${GNOSIS_CHAIN_ID}) for on-chain wake-up.`)
+
+      return
+    }
+
+    setNotifying(true)
+    setError(null)
+    const myAddr = signer.getAddress()
+    const provider = sendOnChain && walletClient ? createNotifyProvider(walletClient) : null
+
+    for (const { member, contact } of pendingNotify) {
+      setNotifyStatus(prev => ({ ...prev, [contact.id]: 'sending' }))
+      try {
+        const role: DriveRole = member.role === 'writer' ? 'writer' : 'reader'
+        const granteePub = secp256k1.ProjectivePoint.fromHex(contact.walletPublicKey).toRawBytes(false)
+        const writeKeyBlob =
+          role === 'writer' && drive.writeKey
+            ? await encryptWriteKeyForWriter(hexToBytes(drive.writeKey), granteePub)
+            : undefined
+        const link = buildV2ShareLink(drive, role, writeKeyBlob, {
+          addr: myAddr,
+          walletPublicKey: bytesToHex(signer.getPublicKey()),
+        })
+
+        await mailbox.send(
+          bee,
+          signer.getSigningKey(),
+          drive.cachedHistoryRef ?? '',
+          signer.getSigningKey(),
+          myAddr,
+          toLibraryContact(contact),
+          {
+            subject: `Drive shared: ${drive.name}`,
+            body: 'Drive shared. Open Nook to add it.',
+            type: 'drive-share',
+            driveShareLink: link,
+            driveName: drive.name,
+            fileCount: 0,
+          },
+        )
+
+        const threads = loadThreads()
+        appendSentDriveShare(threads, contact.id, { driveShareLink: link, driveName: drive.name, fileCount: 0 })
+        setNotifyStatus(prev => ({ ...prev, [contact.id]: 'sent' }))
+      } catch (e) {
+        console.error(`Notify ${contact.nickname} failed:`, e)
+        setNotifyStatus(prev => ({ ...prev, [contact.id]: 'failed' }))
+      }
+
+      if (provider) {
+        setOnChainStatus(prev => ({ ...prev, [contact.id]: 'sending' }))
+        try {
+          await registry.sendNotification(provider, REGISTRY_ADDRESS, hexToBytes(contact.walletPublicKey), contact.id, {
+            sender: signer.getAddress(),
+          })
+          setOnChainStatus(prev => ({ ...prev, [contact.id]: 'sent' }))
+        } catch {
+          setOnChainStatus(prev => ({ ...prev, [contact.id]: 'failed' }))
+        }
+      }
+    }
+    setNotifying(false)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center z-50"
+      style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+      onClick={onClose}
+    >
+      <div
+        className="rounded-xl border p-6 w-[420px] space-y-5"
+        style={{ backgroundColor: 'rgb(var(--bg-surface))' }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Lock size={14} style={{ color: 'rgb(var(--accent))' }} />
+            <p className="text-sm font-semibold">Share "{drive.name}"</p>
+          </div>
+          <button onClick={onClose} style={{ color: 'rgb(var(--fg-muted))' }}>
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Member list */}
+        <div>
+          <p className="text-xs uppercase tracking-widest mb-2" style={{ color: 'rgb(var(--fg-muted))' }}>
+            <Users size={10} className="inline mr-1" />
+            People with access
+          </p>
+          <div
+            className="rounded-lg border divide-y max-h-44 overflow-auto"
+            style={{ borderColor: 'rgb(var(--border))' }}
+          >
+            {members.length === 0 ? (
+              <p className="text-xs p-3" style={{ color: 'rgb(var(--fg-muted))' }}>
+                No members yet.
+              </p>
+            ) : (
+              members.map(m => {
+                const isMe =
+                  m.ethAddress.toLowerCase() === drive.creatorAddress.toLowerCase() && drive.myRole === 'creator'
+                const contact = contacts.find(c => c.id.toLowerCase() === m.ethAddress.toLowerCase())
+                const status = contact ? notifyStatus[contact.id] : undefined
+                const onChain = contact ? onChainStatus[contact.id] : undefined
+
+                return (
+                  <div key={m.ethAddress} className="flex items-center justify-between px-3 py-2 gap-2">
+                    <span className="text-xs truncate flex-1" style={{ color: 'rgb(var(--fg-muted))' }}>
+                      <span className="font-medium mr-1" style={{ color: 'rgb(var(--fg))' }}>
+                        {contact?.nickname ?? `${m.ethAddress.slice(0, 8)}…${m.ethAddress.slice(-4)}`}
+                      </span>
+                      <span
+                        className="text-[10px] px-1.5 py-0.5 rounded mr-1"
+                        style={{ backgroundColor: 'rgba(74,222,128,0.1)', color: '#4ade80' }}
+                      >
+                        {m.role}
+                      </span>
+                      {isMe && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: 'rgb(var(--fg-muted))' }}>
+                          you
+                        </span>
+                      )}
+                      {status === 'sent' && (
+                        <span className="text-[10px] px-1 rounded" style={{ color: '#4ade80' }}>
+                          notified
+                        </span>
+                      )}
+                      {onChain === 'sent' && (
+                        <span className="text-[10px] px-1 rounded" style={{ color: '#60a5fa' }}>
+                          +on-chain
+                        </span>
+                      )}
+                    </span>
+                    {isCreator && !isMe && (
+                      <button
+                        onClick={async () => handleRevoke(m)}
+                        disabled={loading}
+                        className="shrink-0 transition-colors hover:text-red-400 disabled:opacity-40"
+                        style={{ color: 'rgb(var(--fg-muted))' }}
+                        title="Revoke access"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    )}
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </div>
+
+        {/* Add grantee — only creator can manage */}
+        {isCreator && (
+          <div>
+            <p className="text-xs uppercase tracking-widest mb-2" style={{ color: 'rgb(var(--fg-muted))' }}>
+              Add someone
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={newAddress}
+                onChange={e => setNewAddress(e.target.value)}
+                placeholder="Nook address (0x…)"
+                className="flex-1 rounded-lg border px-3 py-2 text-xs font-mono focus:outline-none"
+                style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))' }}
+              />
+              <select
+                value={newRole}
+                onChange={e => setNewRole(e.target.value as DriveRole)}
+                className="rounded-lg border px-2 py-2 text-xs focus:outline-none"
+                style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))' }}
+              >
+                <option value="reader">Can view</option>
+                <option value="writer">Can edit</option>
+              </select>
+              <button
+                onClick={handleGrant}
+                disabled={loading || !newAddress.trim()}
+                className="px-3 py-2 rounded-lg text-xs font-semibold disabled:opacity-40 flex items-center gap-1"
+                style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+              >
+                {loading ? <RefreshCw size={11} className="animate-spin" /> : null}
+                Add
+              </button>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <p className="text-xs" style={{ color: '#ef4444' }}>
+            {error}
+          </p>
+        )}
+
+        {/* Notifications */}
+        {notifiableMembers.length > 0 && (
+          <div className="border-t pt-4 space-y-3" style={{ borderColor: 'rgb(var(--border))' }}>
+            <button
+              onClick={handleNotifyAll}
+              disabled={notifying || pendingNotify.length === 0}
+              className="w-full py-2 rounded-lg text-xs font-semibold flex items-center justify-center gap-1.5 disabled:opacity-40 border"
+              style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))', borderColor: 'rgb(var(--border))' }}
+            >
+              {notifying ? <RefreshCw size={11} className="animate-spin" /> : <Bell size={11} />}
+              {notifying
+                ? 'Sending…'
+                : pendingNotify.length === 0
+                  ? 'All notified'
+                  : `Send notification to ${pendingNotify.map(x => x.contact.nickname).join(', ')}`}
+            </button>
+            <label
+              className="flex items-start gap-2 text-[11px] cursor-pointer"
+              style={{ color: 'rgb(var(--fg-muted))' }}
+            >
+              <input
+                type="checkbox"
+                checked={sendOnChain}
+                onChange={e => setSendOnChain(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                Also send on-chain wake-up (~0.001 xDAI) — for recipients who haven&apos;t added you back yet. Requires
+                wallet on Gnosis Chain.
+              </span>
+            </label>
+          </div>
+        )}
+
+        <p className="text-[10px]" style={{ color: 'rgb(var(--fg-muted))' }}>
+          Revoking access prevents future decryption but doesn't affect previously downloaded content.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/crypto/drive.ts
+++ b/ui/src/crypto/drive.ts
@@ -42,6 +42,7 @@ export function driveFeedTopic(creatorAddress: string, driveId: string): Uint8Ar
     ? creatorAddress.toLowerCase()
     : '0x' + creatorAddress.toLowerCase()
   const input = new TextEncoder().encode(`nook:drive:${normalized}:${driveId}`)
+
   return keccak_256(input)
 }
 

--- a/ui/src/crypto/drive.ts
+++ b/ui/src/crypto/drive.ts
@@ -1,0 +1,67 @@
+import { hmac } from '@noble/hashes/hmac'
+import { sha256 } from '@noble/hashes/sha256'
+import { keccak_256 } from '@noble/hashes/sha3'
+import { secp256k1 } from 'ethereum-cryptography/secp256k1'
+import { crypto as swarmNotifyCrypto } from '@swarm-notify/sdk'
+
+export const CURRENT_WRITE_KEY_VERSION = 1
+
+export interface WriteKey {
+  privateKey: Uint8Array // 32 bytes
+  publicKey: Uint8Array // 33 bytes compressed
+  address: string // 0x...20 bytes ETH address of the write key
+  version: number
+}
+
+/**
+ * Derive the drive's writeKey from the creator's nook signing key.
+ * Version is bumped (by caller) each time a writer is revoked.
+ */
+export function deriveWriteKey(
+  creatorSigningKey: Uint8Array,
+  driveId: string,
+  version: number = CURRENT_WRITE_KEY_VERSION,
+): WriteKey {
+  const label = new TextEncoder().encode(`nook:write:${driveId}:v${version}`)
+  const privateKey = hmac(sha256, creatorSigningKey, label)
+  const publicKey = secp256k1.getPublicKey(privateKey, true)
+
+  const uncompressed = secp256k1.getPublicKey(privateKey, false)
+  const addressBytes = keccak_256(uncompressed.slice(1))
+  const address = '0x' + bytesToHex(addressBytes.slice(-20))
+
+  return { privateKey, publicKey, address, version }
+}
+
+/**
+ * Compute the driveFeed topic from creator address + driveId.
+ * Stable across writeKey rotations.
+ */
+export function driveFeedTopic(creatorAddress: string, driveId: string): Uint8Array {
+  const normalized = creatorAddress.toLowerCase().startsWith('0x')
+    ? creatorAddress.toLowerCase()
+    : '0x' + creatorAddress.toLowerCase()
+  const input = new TextEncoder().encode(`nook:drive:${normalized}:${driveId}`)
+  return keccak_256(input)
+}
+
+export function driveFeedTopicHex(creatorAddress: string, driveId: string): string {
+  return bytesToHex(driveFeedTopic(creatorAddress, driveId))
+}
+
+export async function encryptWriteKeyForWriter(
+  writeKeyPriv: Uint8Array,
+  writerWalletPublicKey: Uint8Array,
+): Promise<Uint8Array> {
+  return swarmNotifyCrypto.eciesEncrypt(writeKeyPriv, writerWalletPublicKey)
+}
+
+export async function decryptWriteKey(blob: Uint8Array, myWalletPrivateKey: Uint8Array): Promise<Uint8Array> {
+  return swarmNotifyCrypto.eciesDecrypt(blob, myWalletPrivateKey)
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}

--- a/ui/src/hooks/useActiveDrive.ts
+++ b/ui/src/hooks/useActiveDrive.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { useSharedDrivesV2, type SharedDriveV2 } from './useSharedDrives'
+
+export interface ActiveDriveCtx {
+  drive: SharedDriveV2 | null
+  writeKeyBytes: Uint8Array | null
+  canWrite: boolean
+}
+
+export function useActiveDrive(): ActiveDriveCtx {
+  const { driveId } = useParams<{ driveId: string }>()
+  const { drives } = useSharedDrivesV2()
+
+  const drive = useMemo(() => drives.find(d => d.driveId === driveId) ?? null, [drives, driveId])
+
+  const writeKeyBytes = useMemo(() => {
+    if (!drive?.writeKey) return null
+    return hexToBytes(drive.writeKey)
+  }, [drive?.writeKey])
+
+  return {
+    drive,
+    writeKeyBytes,
+    canWrite: drive?.myRole === 'creator' || drive?.myRole === 'writer',
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}

--- a/ui/src/hooks/useActiveDrive.ts
+++ b/ui/src/hooks/useActiveDrive.ts
@@ -16,6 +16,7 @@ export function useActiveDrive(): ActiveDriveCtx {
 
   const writeKeyBytes = useMemo(() => {
     if (!drive?.writeKey) return null
+
     return hexToBytes(drive.writeKey)
   }, [drive?.writeKey])
 
@@ -32,5 +33,6 @@ function hexToBytes(hex: string): Uint8Array {
   for (let i = 0; i < out.length; i++) {
     out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
   }
+
   return out
 }

--- a/ui/src/hooks/useInboxPolling.ts
+++ b/ui/src/hooks/useInboxPolling.ts
@@ -7,6 +7,9 @@
  * merges them into the localStorage threads store. Components reading
  * threads from localStorage (Messages page, Layout badge) pick up the
  * changes on their next render or interval tick.
+ *
+ * Also auto-adds v2 shared drives when a drive-share message arrives with
+ * a driveId in the link, so grantees don't need to manually click "Add drive".
  */
 import { Bee } from '@ethersphere/bee-js'
 import { mailbox } from '@swarm-notify/sdk'
@@ -15,10 +18,34 @@ import { useEffect, useMemo } from 'react'
 import { loadThreads, mergeReceived, saveThreads } from '../notify/messages'
 import { loadContacts } from '../notify/storage'
 import { toLibraryContact } from '../notify/types'
+import { decryptWriteKey } from '../crypto/drive'
+import { parseShareLinkTyped, type SharedDriveV2 } from './useSharedDrives'
 import { useDerivedKey } from './useDerivedKey'
 
 const BEE_URL = `${window.location.origin}/bee-api`
 const POLL_INTERVAL_MS = 30_000
+const V2_DRIVES_KEY = 'nook-shared-drives-v2'
+
+/** Load v2 drive IDs directly from localStorage (no React state needed). */
+function loadKnownDriveIds(): Set<string> {
+  try {
+    const stored = JSON.parse(localStorage.getItem(V2_DRIVES_KEY) ?? '[]') as Array<{ driveId: string }>
+    return new Set(stored.map(d => d.driveId))
+  } catch {
+    return new Set()
+  }
+}
+
+/** Persist a new v2 drive directly to localStorage (bypasses React state). */
+function persistNewDrive(drive: SharedDriveV2): void {
+  try {
+    const existing = JSON.parse(localStorage.getItem(V2_DRIVES_KEY) ?? '[]') as SharedDriveV2[]
+    if (existing.some(d => d.driveId === drive.driveId)) return
+    localStorage.setItem(V2_DRIVES_KEY, JSON.stringify([...existing, drive]))
+  } catch {
+    // non-fatal
+  }
+}
 
 export function useInboxPolling(): void {
   const { signer } = useDerivedKey()
@@ -52,6 +79,41 @@ export function useInboxPolling(): void {
         // mergeReceived already persists per call, but call once more here
         // for clarity in case the loop body ever changes.
         saveThreads(threads)
+
+        // Auto-add v2 shared drives from incoming drive-share messages
+        const knownIds = loadKnownDriveIds()
+        for (const { messages } of inbox) {
+          for (const msg of messages) {
+            if (msg.type !== 'drive-share' || !msg.driveShareLink) continue
+            const parsed = parseShareLinkTyped(msg.driveShareLink)
+            if (!parsed || parsed.type !== 'nook-drive-share-v2') continue
+            if (knownIds.has(parsed.driveId)) continue
+
+            let writeKeyHex: string | undefined
+            if (parsed.writeKeyBlob && parsed.role === 'writer') {
+              try {
+                const wkBytes = await decryptWriteKey(hexToBytes(parsed.writeKeyBlob), signer.getSigningKey())
+                writeKeyHex = bytesToHex(wkBytes)
+              } catch {
+                // Decryption failed — add as reader rather than dropping the drive
+              }
+            }
+
+            const drive: SharedDriveV2 = {
+              driveId: parsed.driveId,
+              name: parsed.name,
+              creatorAddress: parsed.creatorAddress,
+              myRole: writeKeyHex ? 'writer' : 'reader',
+              writeKey: writeKeyHex,
+              writeKeyVersion: parsed.writeKeyVersion,
+              walletPublicKey: parsed.walletPublicKey,
+              driveFeedTopic: parsed.driveFeedTopic,
+              addedAt: Date.now(),
+            }
+            persistNewDrive(drive)
+            knownIds.add(parsed.driveId) // deduplicate within this tick
+          }
+        }
       } catch {
         // Network blips happen; the next tick will retry. Don't spam the UI.
       }
@@ -65,4 +127,17 @@ export function useInboxPolling(): void {
       clearInterval(id)
     }
   }, [signer, bee])
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
 }

--- a/ui/src/hooks/useInboxPolling.ts
+++ b/ui/src/hooks/useInboxPolling.ts
@@ -30,6 +30,7 @@ const V2_DRIVES_KEY = 'nook-shared-drives-v2'
 function loadKnownDriveIds(): Set<string> {
   try {
     const stored = JSON.parse(localStorage.getItem(V2_DRIVES_KEY) ?? '[]') as Array<{ driveId: string }>
+
     return new Set(stored.map(d => d.driveId))
   } catch {
     return new Set()
@@ -40,6 +41,7 @@ function loadKnownDriveIds(): Set<string> {
 function persistNewDrive(drive: SharedDriveV2): void {
   try {
     const existing = JSON.parse(localStorage.getItem(V2_DRIVES_KEY) ?? '[]') as SharedDriveV2[]
+
     if (existing.some(d => d.driveId === drive.driveId)) return
     localStorage.setItem(V2_DRIVES_KEY, JSON.stringify([...existing, drive]))
   } catch {
@@ -86,10 +88,13 @@ export function useInboxPolling(): void {
           for (const msg of messages) {
             if (msg.type !== 'drive-share' || !msg.driveShareLink) continue
             const parsed = parseShareLinkTyped(msg.driveShareLink)
+
             if (!parsed || parsed.type !== 'nook-drive-share-v2') continue
+
             if (knownIds.has(parsed.driveId)) continue
 
             let writeKeyHex: string | undefined
+
             if (parsed.writeKeyBlob && parsed.role === 'writer') {
               try {
                 const wkBytes = await decryptWriteKey(hexToBytes(parsed.writeKeyBlob), signer.getSigningKey())
@@ -133,6 +138,7 @@ function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith('0x') ? hex.slice(2) : hex
   const out = new Uint8Array(clean.length / 2)
   for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+
   return out
 }
 

--- a/ui/src/hooks/useMemberList.ts
+++ b/ui/src/hooks/useMemberList.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { Bee } from '@ethersphere/bee-js'
+import { secp256k1 } from 'ethereum-cryptography/secp256k1'
+import { fetchMemberList, verifyMemberList, type MemberListDoc } from '../api/memberList'
+import type { SharedDriveV2 } from './useSharedDrives'
+
+const BEE_URL = `${window.location.origin}/bee-api`
+
+export function useMemberList(drive: SharedDriveV2): MemberListDoc | null {
+  const [doc, setDoc] = useState<MemberListDoc | null>(null)
+
+  useEffect(() => {
+    if (!drive.cachedMemberListRef) {
+      setDoc(null)
+      return
+    }
+
+    let cancelled = false
+    const bee = new Bee(BEE_URL)
+
+    async function load() {
+      const ref = hexToBytes(drive.cachedMemberListRef!)
+      const fetched = await fetchMemberList(bee, ref)
+      if (cancelled) return
+
+      if (fetched && drive.walletPublicKey) {
+        const creatorPub = secp256k1.ProjectivePoint.fromHex(drive.walletPublicKey).toRawBytes(false)
+        if (!verifyMemberList(fetched, creatorPub)) {
+          console.warn('useMemberList: signature verification failed for drive', drive.driveId)
+          setDoc(null)
+          return
+        }
+      }
+      setDoc(fetched)
+    }
+
+    load().catch(err => {
+      if (!cancelled) console.error('useMemberList: fetch failed', err)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [drive.cachedMemberListRef, drive.walletPublicKey, drive.driveId])
+
+  return doc
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  return out
+}

--- a/ui/src/hooks/useMemberList.ts
+++ b/ui/src/hooks/useMemberList.ts
@@ -12,6 +12,7 @@ export function useMemberList(drive: SharedDriveV2): MemberListDoc | null {
   useEffect(() => {
     if (!drive.cachedMemberListRef) {
       setDoc(null)
+
       return
     }
 
@@ -21,13 +22,16 @@ export function useMemberList(drive: SharedDriveV2): MemberListDoc | null {
     async function load() {
       const ref = hexToBytes(drive.cachedMemberListRef!)
       const fetched = await fetchMemberList(bee, ref)
+
       if (cancelled) return
 
       if (fetched && drive.walletPublicKey) {
         const creatorPub = secp256k1.ProjectivePoint.fromHex(drive.walletPublicKey).toRawBytes(false)
+
         if (!verifyMemberList(fetched, creatorPub)) {
           console.warn('useMemberList: signature verification failed for drive', drive.driveId)
           setDoc(null)
+
           return
         }
       }
@@ -50,5 +54,6 @@ function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith('0x') ? hex.slice(2) : hex
   const out = new Uint8Array(clean.length / 2)
   for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+
   return out
 }

--- a/ui/src/hooks/useSharedDrives.ts
+++ b/ui/src/hooks/useSharedDrives.ts
@@ -104,6 +104,7 @@ export function useSharedDrivesV2() {
       if (prev.some(d => d.driveId === drive.driveId)) return prev
       const next = [...prev, drive]
       persistV2(next)
+
       return next
     })
   }
@@ -112,6 +113,7 @@ export function useSharedDrivesV2() {
     setDrives(prev => {
       const next = prev.map(d => (d.driveId === driveId ? { ...d, ...patch } : d))
       persistV2(next)
+
       return next
     })
   }
@@ -120,6 +122,7 @@ export function useSharedDrivesV2() {
     setDrives(prev => {
       const next = prev.filter(d => d.driveId !== driveId)
       persistV2(next)
+
       return next
     })
   }
@@ -160,14 +163,17 @@ export function parseShareLinkTyped(link: string): ParsedShareLinkTyped | null {
   try {
     const trimmed = link.trim()
     const NOOK_PREFIX = 'nook://drive-share?'
+
     if (!trimmed.startsWith(NOOK_PREFIX)) return null
     const params = new URLSearchParams(trimmed.slice(NOOK_PREFIX.length))
 
     const driveId = params.get('driveId')
+
     if (driveId) {
       const creator = params.get('creator')?.toLowerCase()
       const topic = params.get('topic')
       const pub = params.get('pub')
+
       if (!creator || !topic || !pub) return null
       const version = parseInt(params.get('version') ?? '1', 10)
       const name = decodeURIComponent(params.get('name') ?? '')
@@ -176,18 +182,32 @@ export function parseShareLinkTyped(link: string): ParsedShareLinkTyped | null {
       const addr = params.get('addr')
       const wpub = params.get('wpub')
       const sender = addr && wpub ? { addr, walletPublicKey: wpub, beePublicKey: pub, name: undefined } : undefined
-      return { type: 'nook-drive-share-v2', driveId, creatorAddress: creator, driveFeedTopic: topic, walletPublicKey: pub, writeKeyVersion: version, name, role, writeKeyBlob, sender }
+
+      return {
+        type: 'nook-drive-share-v2',
+        driveId,
+        creatorAddress: creator,
+        driveFeedTopic: topic,
+        walletPublicKey: pub,
+        writeKeyVersion: version,
+        name,
+        role,
+        writeKeyBlob,
+        sender,
+      }
     }
 
     // v1 legacy
     const feedTopic = params.get('topic')
     const feedOwner = params.get('owner')
     const actPublisher = params.get('publisher')
+
     if (!feedTopic || !feedOwner || !actPublisher) return null
     const addr = params.get('addr')
     const wpub = params.get('wpub')
     const name = params.get('name') ?? undefined
     const sender = addr && wpub ? { addr, walletPublicKey: wpub, beePublicKey: actPublisher, name } : undefined
+
     return { type: 'nook-drive-share-v1', feedTopic, feedOwner, actPublisher, sender }
   } catch {
     return null
@@ -209,11 +229,14 @@ export function buildV2ShareLink(
     name: drive.name,
     role,
   })
+
   if (role === 'writer' && writeKeyBlob) params.set('writeKey', bytesToHex(writeKeyBlob))
+
   if (sender) {
     params.set('addr', sender.addr)
     params.set('wpub', sender.walletPublicKey)
   }
+
   return `nook://drive-share?${params.toString()}`
 }
 

--- a/ui/src/hooks/useSharedDrives.ts
+++ b/ui/src/hooks/useSharedDrives.ts
@@ -1,10 +1,14 @@
 /**
  * Shared drives — drives other users have shared with you via share links.
  * Stored in localStorage. Read-only (you can download but not upload).
+ *
+ * Legacy drives use STORAGE_KEY ('nook-shared-drives').
+ * V2 ACT-backed drives use STORAGE_KEY_V2 ('nook-shared-drives-v2').
  */
 import { useState } from 'react'
 
 const STORAGE_KEY = 'nook-shared-drives'
+const STORAGE_KEY_V2 = 'nook-shared-drives-v2'
 
 export interface SharedFile {
   name: string
@@ -57,6 +61,166 @@ export interface ParsedShareLink {
   actPublisher: string
   /** Present when sender bundled contact info in the link. */
   sender?: SenderContactInfo
+}
+
+// ─── V2 shared drive types ─────────────────────────────────────────────────
+
+export type DriveRole = 'creator' | 'writer' | 'reader'
+
+/** V2 ACT-backed shared drive record stored in nook-shared-drives-v2. */
+export interface SharedDriveV2 {
+  driveId: string
+  name: string
+  creatorAddress: string
+  myRole: DriveRole
+  writeKey?: string // hex 32-byte private key (creator + writers only)
+  writeKeyVersion: number
+  walletPublicKey?: string // creator's compressed-hex pubkey (for ACT + ECIES)
+  driveFeedTopic: string // hex 32-byte topic
+  cachedHistoryRef?: string
+  cachedManifestRef?: string
+  cachedMemberListRef?: string
+  addedAt: number
+  lastSyncAt?: number
+}
+
+function loadV2(): SharedDriveV2[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY_V2) ?? '[]')
+  } catch {
+    return []
+  }
+}
+
+function persistV2(drives: SharedDriveV2[]) {
+  localStorage.setItem(STORAGE_KEY_V2, JSON.stringify(drives))
+}
+
+export function useSharedDrivesV2() {
+  const [drives, setDrives] = useState<SharedDriveV2[]>(loadV2)
+
+  function addDrive(drive: SharedDriveV2) {
+    setDrives(prev => {
+      if (prev.some(d => d.driveId === drive.driveId)) return prev
+      const next = [...prev, drive]
+      persistV2(next)
+      return next
+    })
+  }
+
+  function updateDrive(driveId: string, patch: Partial<SharedDriveV2>) {
+    setDrives(prev => {
+      const next = prev.map(d => (d.driveId === driveId ? { ...d, ...patch } : d))
+      persistV2(next)
+      return next
+    })
+  }
+
+  function removeDrive(driveId: string) {
+    setDrives(prev => {
+      const next = prev.filter(d => d.driveId !== driveId)
+      persistV2(next)
+      return next
+    })
+  }
+
+  function getDrive(driveId: string): SharedDriveV2 | undefined {
+    return drives.find(d => d.driveId === driveId)
+  }
+
+  return { drives, addDrive, updateDrive, removeDrive, getDrive }
+}
+
+// ─── Share link parsing (v1 legacy + v2) ───────────────────────────────────
+
+export interface ParsedShareLinkV1 extends ParsedShareLink {
+  type: 'nook-drive-share-v1'
+}
+
+export interface ParsedShareLinkV2 {
+  type: 'nook-drive-share-v2'
+  driveId: string
+  creatorAddress: string
+  driveFeedTopic: string
+  walletPublicKey: string
+  writeKeyVersion: number
+  name: string
+  role: 'reader' | 'writer'
+  writeKeyBlob?: string
+  sender?: SenderContactInfo
+}
+
+export type ParsedShareLinkTyped = ParsedShareLinkV1 | ParsedShareLinkV2
+
+/**
+ * Parse a `nook://drive-share?...` link.
+ * Returns typed discriminated union: v2 (has driveId) or v1 legacy.
+ */
+export function parseShareLinkTyped(link: string): ParsedShareLinkTyped | null {
+  try {
+    const trimmed = link.trim()
+    const NOOK_PREFIX = 'nook://drive-share?'
+    if (!trimmed.startsWith(NOOK_PREFIX)) return null
+    const params = new URLSearchParams(trimmed.slice(NOOK_PREFIX.length))
+
+    const driveId = params.get('driveId')
+    if (driveId) {
+      const creator = params.get('creator')?.toLowerCase()
+      const topic = params.get('topic')
+      const pub = params.get('pub')
+      if (!creator || !topic || !pub) return null
+      const version = parseInt(params.get('version') ?? '1', 10)
+      const name = decodeURIComponent(params.get('name') ?? '')
+      const role = (params.get('role') ?? 'reader') as 'reader' | 'writer'
+      const writeKeyBlob = params.get('writeKey') ?? undefined
+      const addr = params.get('addr')
+      const wpub = params.get('wpub')
+      const sender = addr && wpub ? { addr, walletPublicKey: wpub, beePublicKey: pub, name: undefined } : undefined
+      return { type: 'nook-drive-share-v2', driveId, creatorAddress: creator, driveFeedTopic: topic, walletPublicKey: pub, writeKeyVersion: version, name, role, writeKeyBlob, sender }
+    }
+
+    // v1 legacy
+    const feedTopic = params.get('topic')
+    const feedOwner = params.get('owner')
+    const actPublisher = params.get('publisher')
+    if (!feedTopic || !feedOwner || !actPublisher) return null
+    const addr = params.get('addr')
+    const wpub = params.get('wpub')
+    const name = params.get('name') ?? undefined
+    const sender = addr && wpub ? { addr, walletPublicKey: wpub, beePublicKey: actPublisher, name } : undefined
+    return { type: 'nook-drive-share-v1', feedTopic, feedOwner, actPublisher, sender }
+  } catch {
+    return null
+  }
+}
+
+export function buildV2ShareLink(
+  drive: SharedDriveV2,
+  role: 'reader' | 'writer',
+  writeKeyBlob?: Uint8Array,
+  sender?: { addr: string; walletPublicKey: string },
+): string {
+  const params = new URLSearchParams({
+    driveId: drive.driveId,
+    creator: drive.creatorAddress,
+    topic: drive.driveFeedTopic,
+    pub: drive.walletPublicKey!,
+    version: String(drive.writeKeyVersion),
+    name: drive.name,
+    role,
+  })
+  if (role === 'writer' && writeKeyBlob) params.set('writeKey', bytesToHex(writeKeyBlob))
+  if (sender) {
+    params.set('addr', sender.addr)
+    params.set('wpub', sender.walletPublicKey)
+  }
+  return `nook://drive-share?${params.toString()}`
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
 }
 
 /**

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -22,6 +22,7 @@ import {
   Upload,
   Users,
 } from 'lucide-react'
+import { Bee } from '@ethersphere/bee-js'
 import { useQueryClient } from '@tanstack/react-query'
 import React, { useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
@@ -43,7 +44,7 @@ import { useAddresses, useBuyStamp, useChainState, useStamps, useTopupStamp, use
 import { useAppStore } from '../store/app'
 import { useDerivedKey } from '../hooks/useDerivedKey'
 import { useDriveMetadata } from '../hooks/useDriveMetadata'
-import { useSharedDrives } from '../hooks/useSharedDrives'
+import { useSharedDrives, useSharedDrivesV2, type SharedDriveV2 } from '../hooks/useSharedDrives'
 import { useUploadHistory, type DriveFolder, type UploadRecord } from '../hooks/useUploadHistory'
 import {
   detectIndexDocument,
@@ -52,9 +53,11 @@ import {
   totalSize,
   type FileEntry,
 } from '../utils/directory'
+import { createSharedDrive } from '../api/createSharedDrive'
 import AddSharedDriveModal from '../components/AddSharedDriveModal'
 import ENSModal from '../components/ENSModal'
 import ShareModal from '../components/ShareModal'
+import ShareModalV2 from '../components/ShareModalV2'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -1765,6 +1768,152 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
   )
 }
 
+// ─── CreateCollaborativeDriveModal ────────────────────────────────────────────
+
+const BEE_URL = `${window.location.origin}/bee-api`
+
+function CreateCollaborativeDriveModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void
+  onCreated: (drive: SharedDriveV2) => void
+}) {
+  const { data: stamps } = useStamps()
+  const { signer, derive } = useDerivedKey()
+  const [name, setName] = useState('')
+  const [stampId, setStampId] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const usableStamps = (stamps ?? []).filter(s => s.usable)
+
+  useEffect(() => {
+    if (!stampId && usableStamps.length > 0) setStampId(usableStamps[0].batchID)
+  }, [usableStamps.length]) // eslint-disable-line
+
+  async function handleCreate() {
+    if (!name.trim() || !stampId) return
+    setCreating(true)
+    setError(null)
+    try {
+      let activeSigner = signer
+
+      if (!activeSigner) activeSigner = await derive()
+
+      if (!activeSigner) {
+        setError('Connect your wallet to create a collaborative drive.')
+        setCreating(false)
+
+        return
+      }
+      const bee = new Bee(BEE_URL)
+      const creatorAddress = activeSigner.getAddress()
+      const { drive } = await createSharedDrive({
+        bee,
+        signer: activeSigner,
+        creatorAddress,
+        stamp: stampId,
+        name: name.trim(),
+      })
+      onCreated(drive)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not create drive.')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center z-50"
+      style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+      onClick={onClose}
+    >
+      <div
+        className="rounded-xl border p-6 w-96 space-y-5"
+        style={{ backgroundColor: 'rgb(var(--bg-surface))' }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2">
+          <Users size={14} style={{ color: 'rgb(var(--accent))' }} />
+          <p className="text-sm font-semibold">New collaborative drive</p>
+        </div>
+
+        <div>
+          <p className="text-xs uppercase tracking-widest mb-2" style={{ color: 'rgb(var(--fg-muted))' }}>
+            Drive name <span style={{ color: '#ef4444' }}>*</span>
+          </p>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && void handleCreate()}
+            placeholder="e.g. Team docs, Shared photos…"
+            className="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none"
+            style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))' }}
+            autoFocus
+          />
+        </div>
+
+        <div>
+          <p className="text-xs uppercase tracking-widest mb-2" style={{ color: 'rgb(var(--fg-muted))' }}>
+            Storage drive
+          </p>
+          {usableStamps.length === 0 ? (
+            <p className="text-xs" style={{ color: '#ef4444' }}>
+              No usable drives found. Buy a drive first from "My Drives".
+            </p>
+          ) : (
+            <select
+              value={stampId}
+              onChange={e => setStampId(e.target.value)}
+              className="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none"
+              style={{ backgroundColor: 'rgb(var(--bg))', color: 'rgb(var(--fg))' }}
+            >
+              {usableStamps.map(s => (
+                <option key={s.batchID} value={s.batchID}>
+                  {s.label || `${s.batchID.slice(0, 12)}…`} · {ttlToDays(s.batchTTL)} left
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <p className="text-xs" style={{ color: 'rgb(var(--fg-muted))' }}>
+          Files are stored encrypted on your drive. You can grant others read or write access after creation.
+        </p>
+
+        {error && (
+          <p className="text-xs" style={{ color: '#ef4444' }}>
+            {error}
+          </p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 py-2 rounded-lg text-sm"
+            style={{ color: 'rgb(var(--fg-muted))' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleCreate()}
+            disabled={creating || !name.trim() || !stampId}
+            className="flex-1 py-2 rounded-lg text-sm font-semibold disabled:opacity-40 flex items-center justify-center gap-2"
+            style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+          >
+            {creating && <RefreshCw size={13} className="animate-spin" />}
+            {creating ? 'Creating…' : 'Create drive'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ─── Main component ────────────────────────────────────────────────────────────
 
 // ─── SharedDriveCard ──────────────────────────────────────────────────────────
@@ -2046,6 +2195,7 @@ export default function Drive() {
   const location = useLocation()
   const driveMetadata = useDriveMetadata()
   const sharedDrives = useSharedDrives()
+  const sharedDrivesV2 = useSharedDrivesV2()
 
   const [customDriveLabels, setCustomDriveLabels] = useState<Record<string, string>>(() => {
     try {
@@ -2069,6 +2219,8 @@ export default function Drive() {
   const [showExtendModal, setShowExtendModal] = useState<string | null>(null) // batchID
   const [showShareModal, setShowShareModal] = useState<string | null>(null) // batchID
   const [showAddSharedModal, setShowAddSharedModal] = useState(false)
+  const [showCreateSharedModal, setShowCreateSharedModal] = useState(false)
+  const [showShareModalV2, setShowShareModalV2] = useState<SharedDriveV2 | null>(null)
   const [driveTab, setDriveTab] = useState<'mine' | 'shared'>('mine')
   const [addingFile, setAddingFile] = useState(false)
   const [search, setSearch] = useState('')
@@ -2181,14 +2333,24 @@ export default function Drive() {
               New drive
             </button>
           ) : (
-            <button
-              onClick={() => setShowAddSharedModal(true)}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold shrink-0"
-              style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
-            >
-              <Plus size={12} />
-              Add shared drive
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowCreateSharedModal(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium shrink-0"
+                style={{ color: 'rgb(var(--fg-muted))' }}
+              >
+                <Users size={12} />
+                New collaborative
+              </button>
+              <button
+                onClick={() => setShowAddSharedModal(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold shrink-0"
+                style={{ backgroundColor: 'rgb(var(--accent))', color: '#fff' }}
+              >
+                <Plus size={12} />
+                Add shared drive
+              </button>
+            </div>
           )}
         </div>
 
@@ -2214,7 +2376,10 @@ export default function Drive() {
                 : { color: 'rgb(var(--fg-muted))' }
             }
           >
-            Shared with me{sharedDrives.drives.length > 0 ? ` (${sharedDrives.drives.length})` : ''}
+            Shared with me
+            {sharedDrives.drives.length + sharedDrivesV2.drives.length > 0
+              ? ` (${sharedDrives.drives.length + sharedDrivesV2.drives.length})`
+              : ''}
           </button>
         </div>
 
@@ -2247,12 +2412,50 @@ export default function Drive() {
           </div>
         ) : driveTab === 'shared' ? (
           /* Shared drives tab */
-          sharedDrives.drives.length === 0 ? (
+          sharedDrives.drives.length === 0 && sharedDrivesV2.drives.length === 0 ? (
             <p className="text-xs text-center py-8" style={{ color: 'rgb(var(--fg-muted))' }}>
               No shared drives yet. When someone shares a drive with you, paste the share link here.
             </p>
           ) : (
             <div className="border-t" style={{ borderColor: 'rgb(var(--border))' }}>
+              {sharedDrivesV2.drives.map(drive => (
+                <div
+                  key={drive.driveId}
+                  className="flex items-center justify-between px-4 py-3 border-b"
+                  style={{ borderColor: 'rgb(var(--border))' }}
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{drive.name}</p>
+                    <p className="text-xs mt-0.5" style={{ color: 'rgb(var(--fg-muted))' }}>
+                      <span
+                        className="px-1.5 py-0.5 rounded mr-1 text-[10px]"
+                        style={{ backgroundColor: 'rgba(74,222,128,0.1)', color: '#4ade80' }}
+                      >
+                        {drive.myRole}
+                      </span>
+                      {drive.creatorAddress.slice(0, 8)}…{drive.creatorAddress.slice(-4)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 ml-3">
+                    {drive.myRole === 'creator' && (
+                      <button
+                        onClick={() => setShowShareModalV2(drive)}
+                        className="text-xs px-2 py-1 rounded border"
+                        style={{ borderColor: 'rgb(var(--border))', color: 'rgb(var(--fg-muted))' }}
+                      >
+                        Share
+                      </button>
+                    )}
+                    <button
+                      onClick={() => sharedDrivesV2.removeDrive(drive.driveId)}
+                      className="text-xs px-2 py-1 rounded border"
+                      style={{ borderColor: 'rgb(var(--border))', color: 'rgb(var(--fg-muted))' }}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))}
               {sharedDrives.drives.map(drive => (
                 <SharedDriveCard
                   key={drive.id}
@@ -2326,6 +2529,7 @@ export default function Drive() {
             myPublicKey={nodeAddresses?.publicKey}
             onClose={() => setShowAddSharedModal(false)}
             onAdd={drive => sharedDrives.add(drive)}
+            onAddV2={drive => sharedDrivesV2.addDrive(drive)}
           />
         )}
 
@@ -2366,6 +2570,16 @@ export default function Drive() {
               />
             )
           })()}
+        {showShareModalV2 && <ShareModalV2 drive={showShareModalV2} onClose={() => setShowShareModalV2(null)} />}
+        {showCreateSharedModal && (
+          <CreateCollaborativeDriveModal
+            onClose={() => setShowCreateSharedModal(false)}
+            onCreated={drive => {
+              sharedDrivesV2.addDrive(drive)
+              setShowCreateSharedModal(false)
+            }}
+          />
+        )}
         {updatingRecord && <UpdateFeedModal record={updatingRecord} onClose={() => setUpdatingId(null)} />}
         {retrieveOpen && <RetrieveModal onClose={() => setRetrieveOpen(false)} />}
         {ensRecordId &&


### PR DESCRIPTION
## What this adds

A new **collaborative drive** type that allows multiple users to read from and write to a shared encrypted drive on Swarm, with the creator managing who has access.

This is distinct from the existing shared drive flow, where a drive owner grants their Bee node's ACT key to specific readers. The new model is fully wallet-derived and works across any device — no Bee node key sharing involved.

---

## How it works

### Drive creation

When a user creates a collaborative drive, three things are set up on Swarm:

1. **ACT (Access Control Trie)** — created via [`act-js`](https://github.com/misaakidis/act-js), a browser-side ACT client. The creator's wallet-derived key is the initial grantee.
2. **Drive feed** — a Swarm SOC feed whose topic is `keccak256("nook:drive:<creatorAddr>:<driveId>")`. Each feed entry points to the current encrypted manifest (file list). The feed is signed by a **write key** rather than the wallet key directly.
3. **Write key** — derived deterministically from the creator's Nook signing key: `HMAC-SHA256(creatorSigningKey, "nook:write:<driveId>:v<N>")`. This key controls who can push new entries to the drive feed.

The manifest (a JSON file listing all drive files) is ACT-encrypted so only current grantees can read it. The feed entry stores the encrypted manifest reference alongside the ACT history ref needed to decrypt it.

### Roles

| Role | Can read files | Can push to feed | Holds write key |
|------|---------------|-----------------|-----------------|
| Creator | Yes | Yes | Yes (derived) |
| Writer | Yes | Yes | Yes (encrypted copy) |
| Reader | Yes | No | No |

Readers get ACT access to the encrypted manifest. Writers additionally receive the write key, encrypted with their wallet public key (ECIES via `@swarm-notify/sdk`), so they can post new feed entries.

### Who pays for storage

Each participant uploads to their **own postage stamp**. Writers and readers select which of their own drives to use when uploading a file — they are not uploading onto the creator's stamp. The drive feed and ACT state live on the creator's stamp; file data lives on whoever uploaded it.

### Granting and revoking access

The creator uses a new **Share** modal (`ShareModalV2`) to manage members:

- **Grant**: calls `ActClient.patchGrantees({ add: [writerPublicKey] })` to extend ACT access, then sends the grantee a share link via Nook messaging. Writer links include the write key encrypted specifically for that recipient's wallet public key.
- **Revoke reader**: removes them from the ACT grantee list. The manifest is re-encrypted with the updated history.
- **Revoke writer**: removes ACT access, rotates the write key (version bump), re-derives it, and re-encrypts it for all remaining writers. Old write key holders can no longer push valid feed entries.

Member state is tracked in a signed **member list document** (creator's secp256k1 signature over canonical JSON) uploaded to Swarm and referenced in the feed entry. This lets any member verify the current access state without trusting a centralised server.

### Receiving a shared drive

Share links use the existing `nook://drive-share` scheme, extended with v2 params (`driveId`, `role`, `writeKey`). The presence of `driveId` distinguishes v2 links from legacy ones.

`useInboxPolling` (which already runs in the background at the Layout level) now also scans incoming messages for v2 drive-share links and auto-imports the drive into localStorage — no manual paste needed.

---

## New files

| File | Purpose |
|------|---------|
| `src/crypto/drive.ts` | Write key derivation, drive feed topic, ECIES encrypt/decrypt for write key |
| `src/api/driveFeed.ts` | Read and write drive feed entries (SOC feed via bee-js) |
| `src/api/createSharedDrive.ts` | Create ACT + initial manifest + feed entry |
| `src/api/sharedDriveUpload.ts` | Upload a file to a collaborative drive (decrypt manifest → append → re-encrypt → write feed) |
| `src/api/memberList.ts` | Create, sign, verify, and update the member list document |
| `src/hooks/useSharedDrives.ts` | Extended with `SharedDriveV2` type, `useSharedDrivesV2` hook, v2 link parsing/building |
| `src/hooks/useActiveDrive.ts` | Resolve active drive from route, expose write key bytes and `canWrite` flag |
| `src/hooks/useMemberList.ts` | Fetch and verify member list from Swarm on mount |
| `src/components/ShareModalV2.tsx` | Grant/revoke UI, member list with role badges, notify-all flow |

## Changed files

| File | Change |
|------|--------|
| `src/components/AddSharedDriveModal.tsx` | Handle v2 share links — decrypt write key if present, save to v2 store |
| `src/hooks/useInboxPolling.ts` | Auto-import v2 drives from incoming drive-share messages |
| `src/pages/Drive.tsx` | "Shared with me" tab shows v2 drives with role badge; "New collaborative" button + creation modal; Share button opens `ShareModalV2` |

## Dependency

Adds [`@nook/act-js`](https://github.com/misaakidis/act-js) (`github:misaakidis/act-js`) — a browser-side ACT client that wraps Bee's ACT chunk operations. It exposes `ActClient.create()`, `patchGrantees()`, `encryptRef()`, `decryptRef()`, and `reencryptRef()`. The package builds on install via its `prepare` script.