### PR TITLE
fix(deps): viem 2.54.6 — expired pkg.pr.new ox dep broke npm ci

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -25,7 +25,7 @@
         "react-dom": "^19.2.5",
         "react-router-dom": "^6.26.2",
         "tailwind-merge": "^2.5.3",
-        "viem": "^2.48.0",
+        "viem": "^2.54.6",
         "wagmi": "^2.19.5",
         "zustand": "^5.0.12"
       },
@@ -10222,9 +10222,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.26-386a343.0",
-      "resolved": "https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a",
-      "integrity": "sha512-OHHm9re1yVjiMN66GZ2JSGuqmvJPrk40zh3PIS/3I6prZLbt6U/zKlgW18eIIkO0Y/ZyySKr6D/4mUXjBmky1g==",
+      "version": "0.14.30",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
+      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
       "funding": [
         {
           "type": "github",
@@ -12374,9 +12374,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.51.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.51.0.tgz",
-      "integrity": "sha512-8C0Ca+eEapXE29vHMUW59NqKENl1X4s9P6xSNC9Nvw6EvAeAhn/LNUlgztk6TOw7KN1Gzz5a/n9Wv4okUfmY9g==",
+      "version": "2.54.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.54.6.tgz",
+      "integrity": "sha512-OfybECKJYVmhiNqz+SHhed+O2h6niQ+0Wjg9J0b4bV+/QrvLgjxhfKO7hZqsuK1YtZ/0BErBKy708Zp+cU5T0Q==",
       "funding": [
         {
           "type": "github",
@@ -12391,8 +12391,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a",
-        "ws": "8.20.1"
+        "ox": "0.14.30",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -12416,27 +12416,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^19.2.5",
     "react-router-dom": "^6.26.2",
     "tailwind-merge": "^2.5.3",
-    "viem": "^2.48.0",
+    "viem": "^2.54.6",
     "wagmi": "^2.19.5",
     "zustand": "^5.0.12"
   },


### PR DESCRIPTION
viem 2.51.0's own package.json pins `ox` to an ephemeral pkg.pr.new preview URL that has been garbage-collected — any fresh `npm ci` fails with E404. This broke the post-merge master CI run (the PR run passed only via a warm npm cache) and would fail the v0.5.1 Release workflow.

viem 2.54.6 (in-range minor, wagmi peer `2.x` satisfied) depends on registry `ox@0.14.30`. UI type check + 30 vitest tests pass; `grep pkg.pr.new ui/package-lock.json` → 0.