### PR TITLE
fix: direct upload for message payloads and metadata wrappers (#86)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -302,7 +302,13 @@ export function runServer() {
 
     try {
       const bee = makeBee()
-      const result = await bee.uploadData(stampId, data)
+      // deferred: false — this uploads the public wrapper that a drive's
+      // metadata feed points at. The feed slot itself (SOC) is always pushed
+      // directly by Bee; without this the wrapper could sit in the local
+      // store awaiting the background pusher, and quitting the app right
+      // after sharing strands it — recipients then get "could not access
+      // this drive" even though the feed resolves. See #86.
+      const result = await bee.uploadData(stampId, data, { deferred: false })
       context.body = { reference: result.reference.toHex() }
     } catch (error) {
       logger.error(error)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,7 +14,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@rainbow-me/rainbowkit": "^2.2.10",
-        "@swarm-notify/sdk": "github:GasperX93/swarm-notify#03f4c005eb4329997780f6e0d6d8b6707b8670e7",
+        "@swarm-notify/sdk": "github:GasperX93/swarm-notify#0ed939b9f269072b5985a16493c6babb3e1b8859",
         "@tanstack/react-query": "^5.90.21",
         "@upcoming/multichain-widget": "^0.10.8",
         "class-variance-authority": "^0.7.1",
@@ -5277,8 +5277,8 @@
     },
     "node_modules/@swarm-notify/sdk": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/GasperX93/swarm-notify.git#03f4c005eb4329997780f6e0d6d8b6707b8670e7",
-      "integrity": "sha512-ZglrNriVXbMrHrq/83uE4+6NvFp/r/sQmgeNcICefHtbhOZ2SSvf1N5+r7z9hERBsDhCU4eiBc0gK+Ov2fVjIA==",
+      "resolved": "git+ssh://git@github.com/GasperX93/swarm-notify.git#0ed939b9f269072b5985a16493c6babb3e1b8859",
+      "integrity": "sha512-GLs4Awja3UFhlRaiNJLDk3OjE8BEPWzFGuzAd/6kuPe2hMKuojmSkscqrWBjnXSvP80N0ZYNF4kohjg2flj87Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@noble/hashes": "^1.7.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@rainbow-me/rainbowkit": "^2.2.10",
-    "@swarm-notify/sdk": "github:GasperX93/swarm-notify#03f4c005eb4329997780f6e0d6d8b6707b8670e7",
+    "@swarm-notify/sdk": "github:GasperX93/swarm-notify#0ed939b9f269072b5985a16493c6babb3e1b8859",
     "@tanstack/react-query": "^5.90.21",
     "@upcoming/multichain-widget": "^0.10.8",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Implements the fix from the #86 investigation (Bee `/soc` vs `/bytes` default analysis).

- **Nook** `/upload-bytes` (drive-metadata feed wrapper): `deferred: false`
- **SDK repin** → swarm-notify `0ed939b` (GasperX93/swarm-notify#58): `mailbox.send` payload upload now `deferred: false`

Use case fixed: send a message (or share a drive) and quit the app right after — previously the payload could stay stranded in the local store while the feed pointer was already live, silently freezing the recipient's inbox at that index (or giving 'could not access this drive'). Now the send/share call only returns once the payload is on the network.

Verified: types clean, lint 0 errors, 28 backend + 30 UI tests, SDK 76/76; installed SDK dist confirmed to carry the flag.

Closes #86