### PR TITLE
feat: Bee 2.8.1 features — drive rename, honest usage, validity floor

### DIFF
--- a/ui/src/api/bee.ts
+++ b/ui/src/api/bee.ts
@@ -81,6 +81,8 @@ export interface NodeAddresses {
 export interface Stamp {
   batchID: string
   utilization: number
+  /** True fractional usage 0–1 (Bee ≥ 2.8.1). Prefer over the worst-case `utilization` bucket metric when present. */
+  utilizationRatio?: number
   usable: boolean
   label: string
   depth: number
@@ -96,6 +98,22 @@ export interface ChainState {
   block: number
   totalAmount: string
   currentPrice: string // PLUR per chunk per block
+  /** Minimum batch validity in blocks enforced by the network (Bee ≥ 2.8.1). */
+  minimumValidityBlocks?: number
+}
+
+/**
+ * Effective fill ratio 0–1 for a stamp. Uses Bee 2.8.1's `utilizationRatio`
+ * (true fractional usage) when the node provides it; falls back to the
+ * worst-case bucket-fill estimate (`utilization / 2^(depth-bucketDepth)`) on
+ * older nodes. The fallback is systematically pessimistic — that's why the
+ * ratio is preferred.
+ */
+export function stampFillRatio(stamp: Stamp): number {
+  if (typeof stamp.utilizationRatio === 'number') return Math.min(stamp.utilizationRatio, 1)
+  const maxUtilization = 1 << (stamp.depth - stamp.bucketDepth)
+
+  return maxUtilization > 0 ? Math.min(stamp.utilization / maxUtilization, 1) : 0
 }
 
 export interface UploadResult {
@@ -186,9 +204,21 @@ export function calcStampCost(
   depth: number,
   months: number,
   currentPrice: string,
+  minimumValidityBlocks?: number,
 ): { amount: string; bzzCost: string } {
   const price = BigInt(currentPrice)
-  const durationBlocks = BigInt(months) * BLOCKS_PER_MONTH
+  let durationBlocks = BigInt(months) * BLOCKS_PER_MONTH
+
+  // Safety net (Bee ≥ 2.8.1): the network rejects batches below a minimum
+  // validity — a purchase under the floor would waste BZZ. Auto-bump to the
+  // minimum with a 5% margin for price drift between quote and buy; the
+  // returned cost reflects the bump. Presets are far above the floor, so this
+  // only ever fires on misconfiguration or extreme network changes.
+  if (minimumValidityBlocks && minimumValidityBlocks > 0) {
+    const floorBlocks = (BigInt(minimumValidityBlocks) * 105n) / 100n
+
+    if (durationBlocks < floorBlocks) durationBlocks = floorBlocks
+  }
   const amount = price * durationBlocks
   const totalChunks = 1n << BigInt(depth)
   const totalPlur = amount * totalChunks
@@ -263,6 +293,14 @@ export const beeApi = {
     }),
 
   getStamp: async (id: string) => beeRequest<Stamp>(`/stamps/${id}`),
+
+  /** Rename a drive — updates the batch label (local node metadata, no chain tx). Bee ≥ 2.8.1. */
+  renameStamp: async (id: string, label: string) =>
+    beeRequest<{ batchID: string }>(`/stamps/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label }),
+    }),
 
   topupStamp: async (id: string, amount: string) =>
     beeRequest<{ batchID: string }>(`/stamps/topup/${id}/${amount}`, { method: 'PATCH' }),

--- a/ui/src/apps/WebsitePublisher.tsx
+++ b/ui/src/apps/WebsitePublisher.tsx
@@ -107,7 +107,14 @@ export default function WebsitePublisher() {
 
   const selectedSize = SIZE_PRESETS[sizeIdx]
   const selectedDuration = DURATION_PRESETS[durationIdx]
-  const cost = chainState ? calcStampCost(selectedSize.depth, selectedDuration.months, chainState.currentPrice) : null
+  const cost = chainState
+    ? calcStampCost(
+        selectedSize.depth,
+        selectedDuration.months,
+        chainState.currentPrice,
+        chainState.minimumValidityBlocks,
+      )
+    : null
   const bzzBalance = wallet ? Number(plurToBzz(wallet.bzzBalance)) : null
   // Storage already paid for by a failed attempt with the same selection —
   // retry must not re-buy, and must not be blocked by the balance check.

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -39,6 +39,7 @@ import {
   getBeeUrl,
   plurToBzz,
   SIZE_PRESETS,
+  stampFillRatio,
   topicFromString,
   type Stamp,
 } from '../api/bee'
@@ -210,7 +211,14 @@ function BuyDriveModal({
 
   const selectedSize = SIZE_PRESETS[sizeIdx]
   const selectedDuration = DURATION_PRESETS[durationIdx]
-  const cost = chainState ? calcStampCost(selectedSize.depth, selectedDuration.months, chainState.currentPrice) : null
+  const cost = chainState
+    ? calcStampCost(
+        selectedSize.depth,
+        selectedDuration.months,
+        chainState.currentPrice,
+        chainState.minimumValidityBlocks,
+      )
+    : null
   const bzzBalance = wallet ? Number(plurToBzz(wallet.bzzBalance)) : null
   const canAfford = cost && bzzBalance !== null ? bzzBalance >= Number(cost.bzzCost) : true
 
@@ -1107,15 +1115,16 @@ function DriveCard({
   const hasName = Boolean(customName || stamp.label)
   const driveName = customName || stamp.label || `${stamp.batchID.slice(0, 8)}…`
   const capacityBytes = depthToBytes(stamp.depth)
-  const maxUtilization = 1 << (stamp.depth - stamp.bucketDepth)
-  // Use Bee's reported utilization (matches swarm-cli) instead of summing local
-  // upload history — anything uploaded outside Nook (swarm-cli, ACT chunks,
-  // feed updates) wouldn't show up otherwise. Bee's metric is worst-case
-  // bucket-fill, so the byte estimate is conservative.
-  const usedBytes = maxUtilization > 0 ? Math.round(capacityBytes * (stamp.utilization / maxUtilization)) : 0
-  const usagePct = capacityBytes > 0 ? Math.min((usedBytes / capacityBytes) * 100, 100) : 0
-  const utilizationPct = Math.round((stamp.utilization / maxUtilization) * 100)
-  const isFull = stamp.utilization >= maxUtilization
+  // Use Bee's reported fill instead of summing local upload history — anything
+  // uploaded outside Nook (swarm-cli, ACT chunks, feed updates) wouldn't show
+  // up otherwise. stampFillRatio prefers Bee 2.8.1's utilizationRatio (true
+  // fractional usage) and falls back to the pessimistic worst-case bucket-fill
+  // estimate on older nodes.
+  const fillRatio = stampFillRatio(stamp)
+  const usedBytes = Math.round(capacityBytes * fillRatio)
+  const usagePct = Math.min(fillRatio * 100, 100)
+  const utilizationPct = Math.round(fillRatio * 100)
+  const isFull = fillRatio >= 1
   const ttlDays = stamp.batchTTL / 86400
   // Critical = days-pill turns red. Matches Figma's 'red at ≤7 days' threshold.
   const isCriticalTtl = stamp.usable && ttlDays > 0 && ttlDays <= 7
@@ -1993,6 +2002,7 @@ export default function Drive() {
   const driveMetadata = useDriveMetadata()
   const sharedDrives = useSharedDrives()
   const { signer } = useDerivedKey()
+  const queryClient = useQueryClient()
 
   const [customDriveLabels, setCustomDriveLabels] = useState<Record<string, string>>(() => {
     try {
@@ -2003,12 +2013,23 @@ export default function Drive() {
   })
 
   function renameDrive(batchID: string, name: string) {
+    // Optimistic local overlay — shows instantly and doubles as a fallback for
+    // nodes older than Bee 2.8.1 (where PATCH /stamps doesn't exist).
     setCustomDriveLabels(prev => {
       const next = { ...prev, [batchID]: name }
       localStorage.setItem('nook-drive-labels', JSON.stringify(next))
 
       return next
     })
+    // Persist on the node (batch label) — survives reinstall/other browsers,
+    // unlike this origin's localStorage. Best-effort: local rename stands
+    // regardless.
+    beeApi
+      .renameStamp(batchID, name)
+      .then(async () => queryClient.invalidateQueries({ queryKey: ['bee', 'stamps'] }))
+      .catch(() => {
+        // Older node or transient error — the localStorage overlay covers it.
+      })
   }
 
   const [activeDriveId, setActiveDriveId] = useState<string | null>(null)


### PR DESCRIPTION
Implements #83, #84, #85 (the Bee 2.8.1 backlog).

- **#83 rename drives**: existing rename now persists to the node as the batch label (`PATCH /stamps` — verified live against a 2.8.1 node: no auth, JSON body). localStorage overlay = optimistic UI + pre-2.8.1 fallback.
- **#84 honest usage**: `stampFillRatio()` prefers `utilizationRatio`, falls back to worst-case bucket-fill on older nodes. Used bytes / bar / Full badge switched.
- **#85 validity floor**: `calcStampCost` auto-bumps duration to `minimumValidityBlocks` +5% margin; cost display reflects it; both buy surfaces wired; no-op on older nodes.

Verified: types clean, lint 0 errors, 30 UI tests pass.

## Test notes (with the next develop build)
1. Rename a drive → name shows immediately; restart Nook → name persists (now from the node, not just this browser)
2. A freshly bought empty drive shows ~0% used (previously showed a nonzero worst-case number)
3. Buying drives with all presets works unchanged (the floor is a safety net — mainnet minimum is far below 1 month)

Closes #83, closes #84, closes #85