### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.5.2](https://github.com/GasperX93/nook/releases/tag/v0.5.2) (2026-07-14)
+
+### Messaging & sharing reliability
+
+* **Direct network push for message payloads and drive-share metadata** — quitting Nook right after sending could strand a message (or a shared drive's metadata) in the local store: it looked sent, but the recipient's inbox stalled on it forever. Send/share now completes only once the content is on the network ([#86](https://github.com/GasperX93/nook/issues/86), swarm-notify#58). Verified with the "send and quit within 2 seconds" test.
+
+### Drives
+
+* **Rename drives** — hover pencil next to the name (also in the ⋯ menu); names persist on the node via `PATCH /stamps`, surviving reinstalls ([#83](https://github.com/GasperX93/nook/issues/83))
+* **Honest usage display** — usage bars use Bee 2.8.1's true fill ratio instead of the worst-case estimate ([#84](https://github.com/GasperX93/nook/issues/84)); tooltip explains reserved-vs-file-size overhead
+* **Purchase safety net** — drive purchases auto-bump to the network's minimum storage duration ([#85](https://github.com/GasperX93/nook/issues/85))
+
 ## [0.5.1](https://github.com/GasperX93/nook/releases/tag/v0.5.1) (2026-07-08)
 
 ### Bee node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nook",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nook",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@ethersphere/bee-js": "^12.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/ethersphere/swarm-desktop"
     }
   ],
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Permanent decentralized storage for files, folders and websites",
   "repository": "https://github.com/GasperX93/nook",
   "main": "dist/desktop/src/index.js",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nook-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nook-ui",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@ethersphere/bee-js": "^12.3.1",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nook-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "start": "vite --port 3002",

--- a/ui/src/api/bee.ts
+++ b/ui/src/api/bee.ts
@@ -81,6 +81,8 @@ export interface NodeAddresses {
 export interface Stamp {
   batchID: string
   utilization: number
+  /** True fractional usage 0–1 (Bee ≥ 2.8.1). Prefer over the worst-case `utilization` bucket metric when present. */
+  utilizationRatio?: number
   usable: boolean
   label: string
   depth: number
@@ -96,6 +98,22 @@ export interface ChainState {
   block: number
   totalAmount: string
   currentPrice: string // PLUR per chunk per block
+  /** Minimum batch validity in blocks enforced by the network (Bee ≥ 2.8.1). */
+  minimumValidityBlocks?: number
+}
+
+/**
+ * Effective fill ratio 0–1 for a stamp. Uses Bee 2.8.1's `utilizationRatio`
+ * (true fractional usage) when the node provides it; falls back to the
+ * worst-case bucket-fill estimate (`utilization / 2^(depth-bucketDepth)`) on
+ * older nodes. The fallback is systematically pessimistic — that's why the
+ * ratio is preferred.
+ */
+export function stampFillRatio(stamp: Stamp): number {
+  if (typeof stamp.utilizationRatio === 'number') return Math.min(stamp.utilizationRatio, 1)
+  const maxUtilization = 1 << (stamp.depth - stamp.bucketDepth)
+
+  return maxUtilization > 0 ? Math.min(stamp.utilization / maxUtilization, 1) : 0
 }
 
 export interface UploadResult {
@@ -186,9 +204,21 @@ export function calcStampCost(
   depth: number,
   months: number,
   currentPrice: string,
+  minimumValidityBlocks?: number,
 ): { amount: string; bzzCost: string } {
   const price = BigInt(currentPrice)
-  const durationBlocks = BigInt(months) * BLOCKS_PER_MONTH
+  let durationBlocks = BigInt(months) * BLOCKS_PER_MONTH
+
+  // Safety net (Bee ≥ 2.8.1): the network rejects batches below a minimum
+  // validity — a purchase under the floor would waste BZZ. Auto-bump to the
+  // minimum with a 5% margin for price drift between quote and buy; the
+  // returned cost reflects the bump. Presets are far above the floor, so this
+  // only ever fires on misconfiguration or extreme network changes.
+  if (minimumValidityBlocks && minimumValidityBlocks > 0) {
+    const floorBlocks = (BigInt(minimumValidityBlocks) * 105n) / 100n
+
+    if (durationBlocks < floorBlocks) durationBlocks = floorBlocks
+  }
   const amount = price * durationBlocks
   const totalChunks = 1n << BigInt(depth)
   const totalPlur = amount * totalChunks
@@ -263,6 +293,14 @@ export const beeApi = {
     }),
 
   getStamp: async (id: string) => beeRequest<Stamp>(`/stamps/${id}`),
+
+  /** Rename a drive — updates the batch label (local node metadata, no chain tx). Bee ≥ 2.8.1. */
+  renameStamp: async (id: string, label: string) =>
+    beeRequest<{ batchID: string }>(`/stamps/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label }),
+    }),
 
   topupStamp: async (id: string, amount: string) =>
     beeRequest<{ batchID: string }>(`/stamps/topup/${id}/${amount}`, { method: 'PATCH' }),

--- a/ui/src/apps/WebsitePublisher.tsx
+++ b/ui/src/apps/WebsitePublisher.tsx
@@ -107,7 +107,14 @@ export default function WebsitePublisher() {
 
   const selectedSize = SIZE_PRESETS[sizeIdx]
   const selectedDuration = DURATION_PRESETS[durationIdx]
-  const cost = chainState ? calcStampCost(selectedSize.depth, selectedDuration.months, chainState.currentPrice) : null
+  const cost = chainState
+    ? calcStampCost(
+        selectedSize.depth,
+        selectedDuration.months,
+        chainState.currentPrice,
+        chainState.minimumValidityBlocks,
+      )
+    : null
   const bzzBalance = wallet ? Number(plurToBzz(wallet.bzzBalance)) : null
   // Storage already paid for by a failed attempt with the same selection —
   // retry must not re-buy, and must not be blocked by the balance check.

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -67,6 +67,12 @@ import { useSidebar } from '../components/ui/sidebar'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+// Why "used" can read higher than the sum of your files: it shows network
+// storage RESERVED (chunk + version overhead, quantized to bucket slots), not
+// logical file bytes. On small drives the smallest step is capacity/32.
+const USAGE_TOOLTIP =
+  'Network storage reserved — includes chunk and version overhead, so it may read higher than your file sizes on small drives.'
+
 function formatBytes(bytes: number): string {
   if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`
 
@@ -1368,6 +1374,7 @@ function DriveCard({
             className="w-32 h-1 rounded-full shrink-0"
             style={{ backgroundColor: 'rgb(var(--border))' }}
             aria-label={`${Math.round(usagePct)}% used`}
+            title={USAGE_TOOLTIP}
           >
             <div
               className="h-1 rounded-full"
@@ -1377,7 +1384,7 @@ function DriveCard({
               }}
             />
           </div>
-          <span style={{ color: isFull ? '#ef4444' : 'rgb(var(--fg-muted))' }}>
+          <span style={{ color: isFull ? '#ef4444' : 'rgb(var(--fg-muted))' }} title={USAGE_TOOLTIP}>
             {usedBytes > 0 ? `${formatBytes(usedBytes)} / ${formatBytes(capacityBytes)}` : formatBytes(capacityBytes)}
           </span>
           {stamp.usable && (

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1248,7 +1248,23 @@ function DriveCard({
               Name this drive…
             </button>
           ) : (
-            <span className="text-lg font-medium truncate min-w-0">{driveName}</span>
+            <span className="inline-flex items-center gap-1.5 min-w-0 group/drivename">
+              <span className="text-lg font-medium truncate min-w-0">{driveName}</span>
+              {/* Same inline-rename affordance as folders and contacts — the
+                  kebab's Rename item stays as the all-actions fallback. */}
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  setRenameInput(driveName)
+                  setRenaming(true)
+                }}
+                className="opacity-0 group-hover/drivename:opacity-100 transition-opacity shrink-0"
+                style={{ color: 'rgb(var(--fg-muted))' }}
+                aria-label={`Rename ${driveName}`}
+              >
+                <Pencil size={13} />
+              </button>
+            </span>
           )}
 
           {/* Encrypted pill */}

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -39,6 +39,7 @@ import {
   getBeeUrl,
   plurToBzz,
   SIZE_PRESETS,
+  stampFillRatio,
   topicFromString,
   type Stamp,
 } from '../api/bee'
@@ -210,7 +211,14 @@ function BuyDriveModal({
 
   const selectedSize = SIZE_PRESETS[sizeIdx]
   const selectedDuration = DURATION_PRESETS[durationIdx]
-  const cost = chainState ? calcStampCost(selectedSize.depth, selectedDuration.months, chainState.currentPrice) : null
+  const cost = chainState
+    ? calcStampCost(
+        selectedSize.depth,
+        selectedDuration.months,
+        chainState.currentPrice,
+        chainState.minimumValidityBlocks,
+      )
+    : null
   const bzzBalance = wallet ? Number(plurToBzz(wallet.bzzBalance)) : null
   const canAfford = cost && bzzBalance !== null ? bzzBalance >= Number(cost.bzzCost) : true
 
@@ -1107,15 +1115,16 @@ function DriveCard({
   const hasName = Boolean(customName || stamp.label)
   const driveName = customName || stamp.label || `${stamp.batchID.slice(0, 8)}…`
   const capacityBytes = depthToBytes(stamp.depth)
-  const maxUtilization = 1 << (stamp.depth - stamp.bucketDepth)
-  // Use Bee's reported utilization (matches swarm-cli) instead of summing local
-  // upload history — anything uploaded outside Nook (swarm-cli, ACT chunks,
-  // feed updates) wouldn't show up otherwise. Bee's metric is worst-case
-  // bucket-fill, so the byte estimate is conservative.
-  const usedBytes = maxUtilization > 0 ? Math.round(capacityBytes * (stamp.utilization / maxUtilization)) : 0
-  const usagePct = capacityBytes > 0 ? Math.min((usedBytes / capacityBytes) * 100, 100) : 0
-  const utilizationPct = Math.round((stamp.utilization / maxUtilization) * 100)
-  const isFull = stamp.utilization >= maxUtilization
+  // Use Bee's reported fill instead of summing local upload history — anything
+  // uploaded outside Nook (swarm-cli, ACT chunks, feed updates) wouldn't show
+  // up otherwise. stampFillRatio prefers Bee 2.8.1's utilizationRatio (true
+  // fractional usage) and falls back to the pessimistic worst-case bucket-fill
+  // estimate on older nodes.
+  const fillRatio = stampFillRatio(stamp)
+  const usedBytes = Math.round(capacityBytes * fillRatio)
+  const usagePct = Math.min(fillRatio * 100, 100)
+  const utilizationPct = Math.round(fillRatio * 100)
+  const isFull = fillRatio >= 1
   const ttlDays = stamp.batchTTL / 86400
   // Critical = days-pill turns red. Matches Figma's 'red at ≤7 days' threshold.
   const isCriticalTtl = stamp.usable && ttlDays > 0 && ttlDays <= 7
@@ -1993,6 +2002,7 @@ export default function Drive() {
   const driveMetadata = useDriveMetadata()
   const sharedDrives = useSharedDrives()
   const { signer } = useDerivedKey()
+  const queryClient = useQueryClient()
 
   const [customDriveLabels, setCustomDriveLabels] = useState<Record<string, string>>(() => {
     try {
@@ -2003,12 +2013,23 @@ export default function Drive() {
   })
 
   function renameDrive(batchID: string, name: string) {
+    // Optimistic local overlay — shows instantly and doubles as a fallback for
+    // nodes older than Bee 2.8.1 (where PATCH /stamps doesn't exist).
     setCustomDriveLabels(prev => {
       const next = { ...prev, [batchID]: name }
       localStorage.setItem('nook-drive-labels', JSON.stringify(next))
 
       return next
     })
+    // Persist on the node (batch label) — survives reinstall/other browsers,
+    // unlike this origin's localStorage. Best-effort: local rename stands
+    // regardless.
+    beeApi
+      .renameStamp(batchID, name)
+      .then(async () => queryClient.invalidateQueries({ queryKey: ['bee', 'stamps'] }))
+      .catch(() => {
+        // Older node or transient error — the localStorage overlay covers it.
+      })
   }
 
   const [activeDriveId, setActiveDriveId] = useState<string | null>(null)


### PR DESCRIPTION
## Release 0.5.2 — tested on develop (2-machine)

- **#86 fix**: direct network push for message payloads + drive-share metadata wrappers (SDK repin to swarm-notify 0ed939b). Live-verified: message sent + app quit within 2s → arrived; drive share → opened by recipient.
- **#83** rename drives (node-persisted labels) — verified across restart
- **#84** honest usage bars (utilizationRatio) — verified
- **#85** minimum-validity purchase floor — verified (no-op on presets)
- Usage tooltip (#90) + inline rename pencil (#91) — verified

CHANGELOG + version bump included.