### PR TITLE
fix(messaging): gap-tolerant mailbox reader (SDK repin)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,7 +14,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@rainbow-me/rainbowkit": "^2.2.10",
-        "@swarm-notify/sdk": "github:GasperX93/swarm-notify#0ed939b9f269072b5985a16493c6babb3e1b8859",
+        "@swarm-notify/sdk": "github:GasperX93/swarm-notify#c3be281624d9f42775f1f52df521c1632929e387",
         "@tanstack/react-query": "^5.90.21",
         "@upcoming/multichain-widget": "^0.10.8",
         "class-variance-authority": "^0.7.1",
@@ -5277,8 +5277,8 @@
     },
     "node_modules/@swarm-notify/sdk": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/GasperX93/swarm-notify.git#0ed939b9f269072b5985a16493c6babb3e1b8859",
-      "integrity": "sha512-GLs4Awja3UFhlRaiNJLDk3OjE8BEPWzFGuzAd/6kuPe2hMKuojmSkscqrWBjnXSvP80N0ZYNF4kohjg2flj87Q==",
+      "resolved": "git+ssh://git@github.com/GasperX93/swarm-notify.git#c3be281624d9f42775f1f52df521c1632929e387",
+      "integrity": "sha512-kQxuMh+ilMxMj33QXpcOFvghiTx57iPq0xX8lcXUni89xGfbSf5qIG47RHlBhTaslj/WhD+uPUAiacwB+DnEbg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@noble/hashes": "^1.7.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@rainbow-me/rainbowkit": "^2.2.10",
-    "@swarm-notify/sdk": "github:GasperX93/swarm-notify#0ed939b9f269072b5985a16493c6babb3e1b8859",
+    "@swarm-notify/sdk": "github:GasperX93/swarm-notify#c3be281624d9f42775f1f52df521c1632929e387",
     "@tanstack/react-query": "^5.90.21",
     "@upcoming/multichain-widget": "^0.10.8",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Repins @swarm-notify/sdk to c3be281 (swarm-notify#59): missing feed slots trigger an 8-index parallel lookahead instead of ending the inbox walk; unreachable payloads are skipped instead of freezing the thread.

Root cause of the live 'Črt receives nothing' incident: his reader stopped at index 2 of a sparse feed (slots at 0,1,5,8,9,11,12,14,15,17,20,21,22) created by per-origin send cursors. With this fix his client reads all 13 messages.

Cursor unification (the root cause) tracked separately in #47.

UI types clean, 30/30 vitest, SDK 78/78.