### PR TITLE
Release 0.5.3

### DIFF
--- a/.claude/commands/check-deps.md
+++ b/.claude/commands/check-deps.md
@@ -99,4 +99,4 @@ Present results as a single report:
 
 ## Reference
 
-Full dependency documentation: `/Users/gzupan/Downloads/Repos/spindle/projects/nook/notes/dependencies.md`
+Full dependency documentation: `/Users/gzupan/Downloads/Repos/spindle/projects/nook/notes/reference/dependencies.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.5.3](https://github.com/GasperX93/nook/releases/tag/v0.5.3) (2026-07-15)
+
+### Messaging reliability
+
+* **Conversations can no longer freeze** — the inbox reader previously stopped at the first unreadable feed index, so a single gap or unreachable payload in a sender's feed silently hid every later message, forever. The reader now skips past gaps (with a bounded lookahead) and unreachable payloads (swarm-notify#59, [#98](https://github.com/GasperX93/nook/pull/98)). Verified live on an affected conversation: all previously hidden messages delivered.
+
+### Docs
+
+* CLAUDE.md and README updated for the 0.5.x feature set (messaging, contacts, drive rename, honest usage, branch workflow)
+
 ## [0.5.2](https://github.com/GasperX93/nook/releases/tag/v0.5.2) (2026-07-14)
 
 ### Messaging & sharing reliability

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Nook is an Electron-based desktop application that manages a Bee node on the Swarm decentralized storage network. It downloads and runs the Bee binary, exposes a Koa REST API, and serves a custom React dashboard (`ui/`).
 
+## Verify Before You Assert or Change
+
+Do not reason from assumptions, memory, or diff text alone. Every claim about how code behaves must be checked against the actual source before you act on it.
+
+**Before changing code:**
+- Read the function/module you are modifying AND its call sites — not just the lines in the diff. Understand what actually happens, not what the names suggest.
+- If the change depends on the behavior of a dependency (Bee API, a library, another repo), open that source or its docs and confirm. Never assume an API's shape, defaults, or error behavior from its name.
+- If you cannot access the source of truth, say so explicitly and mark the assumption — do not silently build on it.
+
+**Before flagging or "fixing" something as wrong/stale:**
+- Read the full surrounding context (whole section/function, adjacent code, related config), not just the line that looks wrong. The answer is often right next to it.
+- Try to refute your own finding first: "what would make this correct as-is?" Only proceed if it survives.
+- Distinguish confirmed facts from suspicions. Unverified concerns are phrased as questions ("is X intended?"), never as assertions ("X is broken").
+
+**General rule:** a smaller number of verified changes/findings beats broad plausible ones. If verification would take one file read or one command, that read is mandatory — plausible-but-wrong costs far more than the check.
+
 ## Commands
 
 ```bash
@@ -50,8 +66,12 @@ The app has two main layers:
 | `electron.ts` | Electron app lifecycle, tray icon, window management |
 | `server.ts` | Koa HTTP server — REST API + serves React dashboard at `/dashboard` |
 | `launcher.ts` | Spawns the Bee binary as a child process, streams logs |
+| `log-rotator.ts` | Rotation-safe bee log writer (`bee.0.log` active, shift-on-rotate, buffered during rotation) |
 | `lifecycle.ts` | `BeeManager`: start/stop/restart Bee; keep-alive loop |
 | `funding-monitor.ts` | Detects ultra-light/light mode, polls wallet balance via RPC, auto-switches to light mode when funded |
+| `chequebook-monitor.ts` | Auto-funds the chequebook for bandwidth (deposits when balance drops below threshold) |
+| `identity-cache.ts` | Server-side cache for the wallet-derived identity (survives page reloads) |
+| `browser.ts` / `nook-deep-link.ts` | Opens the dashboard in the default browser; `nook://` protocol deep links (contact links) |
 | `status.ts` | `/status` endpoint — exposes `mode` (ultra-light/light), `assetsReady` |
 | `config.ts` | Reads/writes Bee YAML config |
 | `downloader.ts` | Downloads the correct Bee binary version |
@@ -61,15 +81,17 @@ The app has two main layers:
 | `path.ts` | Platform-specific data/log paths |
 | `port.ts` | Finds a free local port |
 
-**Startup sequence** (`index.ts`): migrations → splash → download Bee if needed → API key → free port → start Koa server → init Bee config → launch Bee → start funding monitor → setup tray → keep-alive loop.
+**Startup sequence** (`index.ts`): migrations → splash → download Bee if needed → API key → free port → start Koa server → init Bee config → launch Bee → start funding monitor → start chequebook monitor → setup tray → keep-alive loop.
+
+**Bundled Bee version**: `EXPECTED_BEE_VERSION` in `src/downloader.ts` (currently **2.8.1**). On launch the downloader compares the installed binary's version and force-redownloads on mismatch — existing installs auto-upgrade.
 
 **Ultra-light / light mode**: New installs start in ultra-light mode (`swap-enable: false`, no `blockchain-rpc-endpoint`). Bee API is available immediately without funds. The funding monitor polls wallet balance every 15s. When xDAI is detected: stop Bee → write `blockchain-rpc-endpoint` and `swap-enable: true` → restart in light mode. Postage sync takes ~2–3 minutes thanks to clean snapshot loading.
 
-**Server** (`server.ts`): Koa REST API. Public routes: `/info`, `/price`. Auth-required routes (API key header): `/status`, `/config`, `/logs/*`, `/restart`, `/swap`, `/redeem`, `/buy-stamp`, `/feed-update`, `/feed-read`, `/withdraw`, `/peers`, `/act/*`, `/grantee`, `/upload-bytes`.
+**Server** (`server.ts`): Koa REST API. Serves the dashboard at `/dashboard` (unpacked from asar) and proxies `/bee-api/*` → `http://127.0.0.1:1633/*` (mirrors the Vite dev proxy so renderer code works in dev and prod). Routes: `/info`, `/status`, `/config`, `/logs/*`, `/restart`, `/swap`, `/redeem`, `/buy-stamp`, `/feed-update`, `/feed-read`, `/withdraw`, `/chequebook-withdraw`, `/peers`, `/grantee` (+ `GET|PATCH /grantee/:ref`), `/act/upload-metadata`, `/act/download/:hash`, `/upload-bytes` (direct/non-deferred — see #86), `/identity-cache`.
 
 ### Frontend (`ui/`) — Custom React app
 
-Built with Vite + React 19 + Tailwind + TanStack Query + Zustand. Pages: Publish, Drive, Account, Settings, Logs, Dev. It's built separately, copied into `dist/ui/`, and served by the Koa server. The API key is injected via URL parameter.
+Built with Vite + React 19 + Tailwind (shadcn primitives) + TanStack Query + Zustand. Pages (`ui/src/pages/`): Overview, Drive, AccessOnSwarm, Contacts, Account, Wallet, Identity, Settings, Logs, Dev. Apps (`ui/src/apps/`): Messages, WebsitePublisher. It's built separately, copied into `dist/ui/`, and served by the Koa server. The API key is injected via URL parameter.
 
 Key files:
 - `ui/src/api/bee.ts` — direct Bee node API calls (port 1633). Includes ACT upload/download functions. **Note:** the `immutable` flag for stamp creation is sent as an HTTP **header**, not a query param (e.g. `headers: { immutable: 'false' }`). Default stamp type is **immutable** throughout the UI.
@@ -82,16 +104,26 @@ Key files:
 - `ui/src/hooks/useDerivedKey.ts` — wallet → signer derivation hook with deterministic check
 - `ui/src/components/ShareModal.tsx` — grantee management (grant/revoke), share link generation, contact autocomplete
 - `ui/src/components/AddSharedDriveModal.tsx` — import shared drives from share links, feed-based and snapshot
-- `ui/src/pages/Publish.tsx` — multi-step publish wizard (select → storage → feed → done); sidebar click resets wizard via `location.key`
-- `ui/src/pages/Drive.tsx` — upload history with recursive folder tree (any depth), encrypted drives, ACT uploads, "My Drives" / "Shared with me" tabs, feed-based sync
-- `ui/src/pages/Wallet.tsx` — balances (xDAI/xBZZ), collapsible multichain top-up widget, redeem gift code, swap, sharing key display
-- `ui/src/pages/Account.tsx` — two-tab page: Wallet (navigates to Wallet page) + My Storage (drive list with TTL bars, extend drive, buy new drive)
+- `ui/src/apps/WebsitePublisher.tsx` — publish wizard (select → options → publishing → done); "Permanent address" (feed) defaults ON; remembers a bought-but-unused stamp and reuses it on retry (never double-buys); sidebar click resets wizard via `location.key`
+- `ui/src/pages/Drive.tsx` — drive list (rename via hover pencil or kebab; usage bar from `stampFillRatio`; Extend storage), upload history with recursive folder tree, encrypted drives + ACT uploads, "My Drives" / "Shared with me" tabs, feed-based shared-drive sync, re-publish after revoke
+- `ui/src/lib/republish.ts` — re-encrypt & re-upload a drive's files under its current ACT key (post-revoke recovery)
+- `ui/src/pages/Wallet.tsx` — balances (xDAI/xBZZ), collapsible multichain top-up widget, redeem gift code, swap
+- `ui/src/pages/Account.tsx` — two tabs: Wallet + Identity (Nook address / identity publishing). Drive management lives on the Drive page.
 - `ui/src/pages/Settings.tsx` — two-tab page: General (RPC URL, about) + Network (peer stats, developer mode toggle). Supports `?tab=network` query param.
 - `ui/src/pages/Dev.tsx` — node config editor + live Bee logs + wallet key derivation test + "Exit Developer Mode" button (shown in dev mode only)
 - `ui/src/components/Layout.tsx` — sidebar nav + Bee status banner; dot states: checking (gray), syncing/0 peers (orange), live (green), off (red); funding warning banner when mode is ultra-light
 - `ui/src/hooks/useUploadHistory.ts` — localStorage records + folders with `parentFolderId` for subfolder support; includes `isEncrypted`, `actPublisher`, `actHistoryRef` fields
 - `ui/src/index.css` — global styles + CSS overrides for `@upcoming/multichain-widget` internals (hiding the info banner, asterisks, adjusting min-height)
 - `assets/splash.html` — startup splash screen (dark theme, iA Writer font, no external dependencies)
+
+### Messaging (`ui/src/notify/` + `@swarm-notify/sdk`)
+
+End-to-end encrypted messaging over Swarm feeds, using the **swarm-notify SDK** (pinned by commit in `ui/package.json` to `github:GasperX93/swarm-notify#<rev>`):
+
+- **Append-only mailbox** (v2 feed topic): one message = one immutable feed index. The sender owns a persisted per-recipient **send cursor** (`notify/messages.ts`) so writes never depend on a network read-latest. ALL senders route through `notify/send-message.ts` → `sendMailboxMessage` (cursor + `mailbox.send`); per-recipient serialization via `notify/send-queue.ts`; node-readiness gate via `notify/bee-ready.ts`.
+- **Payloads are direct-pushed** (`deferred: false` in the SDK and in Koa `/upload-bytes`) — "sent" means on-the-network; feed slots (SOC writes) are always direct in Bee.
+- **First contact**: on-chain invitation ping via a notification registry on Gnosis (`registry.sendNotification`, paid by the connected wallet) — surfaces the invite before the recipient has added you back. The **Nook address** is the wallet-DERIVED address (never call it "ETH/wallet address" in UI).
+- Contacts/threads/cursors are localStorage, **namespaced per derived identity** (`notify/active-identity.ts` `nsKey`).
 
 ### ACT encryption architecture
 
@@ -105,7 +137,11 @@ ACT history chaining is critical: every operation returns a new history address 
 
 Share links: `swarm://feed?topic=<hex>&owner=<hex>&publisher=<hex>`. Non-grantees can read the feed but cannot decrypt the metadata (403).
 
-ACT uses the **Bee node's public key** (from `/addresses`) as the sharing key, NOT wallet-derived keys. Wallet-derived keys are reserved for future features (cross-device ACT, Swarm Mail, identity feeds).
+ACT uses the **Bee node's public key** (from `/addresses`) as the sharing key, NOT wallet-derived keys. Wallet-derived keys are used for messaging identity (Nook address); ACT-on-wallet-keys is a future direction.
+
+**Revoke rotates the ACT key** (Bee `pkg/accesscontrol`): content uploaded before a revoke stays encrypted under the OLD key, so a re-granted person can't open it until the drive is **re-published** (`ui/src/lib/republish.ts` re-encrypts files under the current key).
+
+**Shared/encrypted content uploads are direct** (`swarm-deferred-upload: false`) — deferred uploads left chunks on the local light node and recipients got 404s. This applies to ACT file/collection uploads, metadata, and the feed wrapper.
 
 ## UI terminology
 
@@ -133,6 +169,12 @@ Never use "stamp", "postage", or "top up" in user-facing strings.
 - `dist/desktop/` — compiled TypeScript (main process)
 - `dist/ui/` — built React dashboard
 - `out/` — packaged Electron app (after `npm run package`/`make`)
+
+## Branch workflow
+
+- Feature/fix branches PR into **`develop`** (the default branch). develop is the testing ground — merge before testing, fix-forward there.
+- **`master` is release-only** (branch-protected): release = PR develop → master (with version bump + CHANGELOG), `gh pr merge --admin`, tag `vX.Y.Z` on the merge commit. CI attaches Win/Linux assets on the tag; macOS DMG/ZIP are built and uploaded manually.
+- Update `CHANGELOG.md` on every release.
 
 ## Electron & packaging
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ Nook bundles a [Bee](https://github.com/ethersphere/bee) node and a clean UI int
 
 ## What you can do
 
-- **Store files** — upload any file or folder to Swarm, organized into drives with folders
+- **Store files** — upload any file or folder to Swarm, organized into drives with folders. Rename drives, see honest usage, extend before expiry
 - **Encrypt files** — create encrypted drives using Swarm's ACT (chunk-level encryption). Only people you grant access to can decrypt and download
-- **Share encrypted drives** — grant access to specific users via their sharing key, generate a share link, and recipients get a live-syncing view of your files
-- **Publish websites** — upload a website (HTML/CSS/JS) to Swarm and get a permanent link. Optionally attach a feed for updates so the URL stays the same when you publish new versions
+- **Share encrypted drives** — grant access to specific contacts, deliver via a message or share link, and recipients get a live-syncing view of your files. Revoke anytime; re-publish re-secures existing files
+- **Message other Nook users** — end-to-end encrypted messaging over Swarm, no servers. On-chain notification pings reach people even before they've added you back
+- **Contacts & identity** — publish a wallet-derived Nook address so others can find you
+- **Publish websites** — upload a website (HTML/CSS/JS) to Swarm with a permanent address that stays the same when you publish new versions
+- **Access anything on Swarm** — retrieve any Swarm hash and open it in your browser
 - **Connect to ENS** — link your Swarm-hosted website to an ENS domain (e.g. `yourname.eth`) so anyone can access it via a gateway or ENS-aware browser
 - **Manage your wallet** — view xDAI/xBZZ balances, swap between tokens, redeem gift codes, top up from any chain via the multichain widget
 - **Extend storage** — drives have a TTL (time to live). Extend them to keep your data alive longer
@@ -39,7 +42,7 @@ Download the latest build from the [releases page](https://github.com/GasperX93/
 | Linux | `nook_*_amd64.deb` / `nook-*.x86_64.rpm` |
 | Windows | `Nook-*-Setup.exe` |
 
-**macOS note:** Right-click the `.app` → Open to bypass the Gatekeeper warning on first launch (app is not yet notarized).
+**macOS note:** the app is not yet notarized. After downloading, run `xattr -cr ~/Downloads/Nook-*-arm64.dmg`, install, then `xattr -cr /Applications/Nook.app`, and right-click → Open on first launch.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nook",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nook",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@ethersphere/bee-js": "^12.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/ethersphere/swarm-desktop"
     }
   ],
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Permanent decentralized storage for files, folders and websites",
   "repository": "https://github.com/GasperX93/nook",
   "main": "dist/desktop/src/index.js",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,7 +14,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@rainbow-me/rainbowkit": "^2.2.10",
-        "@swarm-notify/sdk": "github:GasperX93/swarm-notify#0ed939b9f269072b5985a16493c6babb3e1b8859",
+        "@swarm-notify/sdk": "github:GasperX93/swarm-notify#c3be281624d9f42775f1f52df521c1632929e387",
         "@tanstack/react-query": "^5.90.21",
         "@upcoming/multichain-widget": "^0.10.8",
         "class-variance-authority": "^0.7.1",
@@ -5277,8 +5277,8 @@
     },
     "node_modules/@swarm-notify/sdk": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/GasperX93/swarm-notify.git#0ed939b9f269072b5985a16493c6babb3e1b8859",
-      "integrity": "sha512-GLs4Awja3UFhlRaiNJLDk3OjE8BEPWzFGuzAd/6kuPe2hMKuojmSkscqrWBjnXSvP80N0ZYNF4kohjg2flj87Q==",
+      "resolved": "git+ssh://git@github.com/GasperX93/swarm-notify.git#c3be281624d9f42775f1f52df521c1632929e387",
+      "integrity": "sha512-kQxuMh+ilMxMj33QXpcOFvghiTx57iPq0xX8lcXUni89xGfbSf5qIG47RHlBhTaslj/WhD+uPUAiacwB+DnEbg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@noble/hashes": "^1.7.2",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nook-ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nook-ui",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@ethersphere/bee-js": "^12.3.1",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nook-ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "scripts": {
     "start": "vite --port 3002",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@rainbow-me/rainbowkit": "^2.2.10",
-    "@swarm-notify/sdk": "github:GasperX93/swarm-notify#0ed939b9f269072b5985a16493c6babb3e1b8859",
+    "@swarm-notify/sdk": "github:GasperX93/swarm-notify#c3be281624d9f42775f1f52df521c1632929e387",
     "@tanstack/react-query": "^5.90.21",
     "@upcoming/multichain-widget": "^0.10.8",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Release 0.5.3 — gap-tolerant messaging

- **fix(messaging)**: gap-tolerant mailbox reader (SDK repin to swarm-notify c3be281, #98) — a missing feed slot or unreachable payload no longer freezes a conversation permanently. **Live-validated**: the affected user's frozen thread delivered all hidden messages after upgrading.
- docs: CLAUDE.md + README updated for 0.5.x
- chore: check-deps skill path fix

CHANGELOG + version bump included.