### PR TITLE
feat(stability): bee supervisor — crash backoff, wedge detection, fetch timeouts (#94)

### DIFF
--- a/src/chequebook-monitor.ts
+++ b/src/chequebook-monitor.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from './fetch-timeout'
 import { logger } from './logger'
 import { getMode } from './funding-monitor'
 import { readConfigYaml } from './config'
@@ -21,7 +22,7 @@ function getAuthHeaders(): Record<string, string> {
 }
 
 async function beeGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${getBeeUrl()}${path}`, { headers: getAuthHeaders() })
+  const res = await fetchWithTimeout(`${getBeeUrl()}${path}`, { headers: getAuthHeaders() }, 10_000)
 
   if (!res.ok) throw new Error(`Bee ${path}: ${res.status}`)
 
@@ -29,7 +30,7 @@ async function beeGet<T>(path: string): Promise<T> {
 }
 
 async function beePost<T>(path: string): Promise<T> {
-  const res = await fetch(`${getBeeUrl()}${path}`, { method: 'POST', headers: getAuthHeaders() })
+  const res = await fetchWithTimeout(`${getBeeUrl()}${path}`, { method: 'POST', headers: getAuthHeaders() }, 30_000)
 
   if (!res.ok) throw new Error(`Bee ${path}: ${res.status}`)
 

--- a/src/fetch-timeout.ts
+++ b/src/fetch-timeout.ts
@@ -1,0 +1,7 @@
+/**
+ * fetch with a hard deadline (#94 part B). Bare `fetch()` in the main process
+ * has no timeout — a hung Bee or network leaves requests pending forever.
+ */
+export async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs = 10_000): Promise<Response> {
+  return fetch(url, { ...options, signal: AbortSignal.timeout(timeoutMs) })
+}

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -3,15 +3,55 @@ import { mkdirSync, writeFileSync } from 'fs'
 import { platform } from 'os'
 import { v4 } from 'uuid'
 import { rebuildElectronTray } from './electron'
+import { fetchWithTimeout } from './fetch-timeout'
 import { BeeManager } from './lifecycle'
 import { RotatingLogWriter } from './log-rotator'
 import { logger } from './logger'
 import { checkPath, getLogPath, getPath } from './path'
+import { canAttemptStart, recordExit, recordStart, shouldRestartForWedge } from './supervisor'
+
+/** Liveness probes for the wedge check (see supervisor.ts). */
+const livenessProbes = {
+  getPeerCount: async (): Promise<number | null> => {
+    try {
+      const res = await fetchWithTimeout('http://localhost:1633/peers', {}, 5_000)
+
+      if (!res.ok) return null
+      const data = (await res.json()) as { peers?: unknown[] }
+
+      return Array.isArray(data.peers) ? data.peers.length : null
+    } catch {
+      return null
+    }
+  },
+  hasInternet: async (): Promise<boolean> => {
+    try {
+      const res = await fetchWithTimeout('https://api.github.com', { method: 'HEAD' }, 5_000)
+
+      return res.ok || res.status < 500
+    } catch {
+      return false
+    }
+  },
+}
 
 export function runKeepAliveLoop() {
-  setInterval(() => {
+  setInterval(async () => {
+    const now = Date.now()
+
     if (!BeeManager.isRunning() && BeeManager.shouldRestart()) {
-      runLauncher()
+      if (canAttemptStart(now)) runLauncher()
+
+      return
+    }
+
+    // Sleep/wake wedge detection: a running node with 0 peers for too long
+    // (while the host has internet) never self-recovers — kill it and let the
+    // next tick relaunch with fresh p2p state.
+    if (BeeManager.isRunning() && BeeManager.shouldRestart()) {
+      if (await shouldRestartForWedge(now, livenessProbes)) {
+        BeeManager.kill()
+      }
     }
   }, 10000)
 }
@@ -60,10 +100,12 @@ export async function runLauncher() {
   const subprocess = launchBee(abortController).catch(reason => {
     logger.error(reason)
   })
+  recordStart(Date.now())
   BeeManager.signalRunning(abortController, subprocess)
   rebuildElectronTray()
   await subprocess
   logger.info('Bee subprocess finished running')
+  recordExit(Date.now())
   abortController.abort()
   BeeManager.signalStopped()
   rebuildElectronTray()

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -38,6 +38,16 @@ export const BeeManager = {
       state.abortController.abort()
     }
   },
+  /**
+   * Kill the Bee process WITHOUT clearing the run intention — the keep-alive
+   * loop relaunches it on its next tick. `stop()` is user intent ("keep it
+   * off"); this is supervision ("bounce it"). Used by the wedge restart.
+   */
+  kill: () => {
+    if (state.abortController) {
+      state.abortController.abort()
+    }
+  },
   waitForSigtermToFinish: async () => {
     if (state.process) {
       await state.process

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,8 @@ import { logger, readNookLogs, readBeeLogs, subscribeLogServerRequests } from '.
 import { getPath } from './path'
 import { port } from './port'
 import { getStatus } from './status'
+import { resetCrashLoop } from './supervisor'
+import { fetchWithTimeout } from './fetch-timeout'
 import { swap } from './swap'
 
 const UI_DIST = path.join(__dirname, '..', '..', 'ui')
@@ -80,7 +82,13 @@ export function runServer() {
     }
 
     try {
-      const res = await fetch(url, { method: context.method, headers, body: body as BodyInit | undefined })
+      // Generous deadline: uploads/downloads through the proxy can be large,
+      // but nothing should hang forever (#94).
+      const res = await fetchWithTimeout(
+        url,
+        { method: context.method, headers, body: body as BodyInit | undefined },
+        5 * 60_000,
+      )
 
       context.status = res.status
       // Forward response headers EXCEPT CORS (Koa CORS middleware adds those —
@@ -202,6 +210,7 @@ export function runServer() {
     }
   })
   router.post('/restart', async context => {
+    resetCrashLoop()
     BeeManager.stop()
     await BeeManager.waitForSigtermToFinish()
     runLauncher()

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { isBeeAssetReady } from './downloader'
 import { BeeMode, getMode } from './funding-monitor'
 import { BeeManager } from './lifecycle'
+import { getSupervisorStatus } from './supervisor'
 import { checkPath, getPath } from './path'
 import { readConfigYaml } from './config'
 
@@ -13,6 +14,8 @@ interface Status {
   mode: BeeMode
   /** True when the user intentionally stopped Bee via the tray menu. */
   userStopped: boolean
+  /** True when Bee crashed repeatedly and the supervisor gave up restarting (#94). */
+  crashLoop: boolean
 }
 
 export function getStatus() {
@@ -20,6 +23,7 @@ export function getStatus() {
     assetsReady: isBeeAssetReady(),
     mode: getMode(),
     userStopped: BeeManager.wasEverStarted() && !BeeManager.shouldRestart(),
+    crashLoop: getSupervisorStatus().crashLoop,
   }
 
   if (!checkPath('config.yaml') || !checkPath('data-dir')) {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1,0 +1,151 @@
+import { logger } from './logger'
+
+/**
+ * Bee process supervision policy (#94): restart backoff, crash-loop detection,
+ * and the sleep/wake liveness check. Pure state machine — the keep-alive loop
+ * in launcher.ts drives it and injects probes, so this stays unit-testable.
+ *
+ * Backoff: a run that dies within FAST_CRASH_MS counts as a fast crash;
+ * consecutive fast crashes double the restart delay (10s → 20s → 40s → … 5min
+ * cap). After MAX_FAST_CRASHES the supervisor stops restarting entirely and
+ * flags `crashLoop` (surfaced on /status → UI banner) until the user retries.
+ *
+ * Liveness: a node that reports 0 peers for ZERO_PEERS_LIMIT_MS while the host
+ * has internet is wedged (classic laptop sleep/wake) — kill it so the
+ * keep-alive relaunches with fresh p2p state. Wedge restarts don't climb the
+ * crash ladder: the run's uptime exceeds FAST_CRASH_MS, so the crash counter
+ * resets on exit.
+ */
+
+const BASE_RESTART_DELAY_MS = 10_000
+const MAX_RESTART_DELAY_MS = 5 * 60_000
+/** A run shorter than this counts as a fast crash. */
+const FAST_CRASH_MS = 60_000
+/** Consecutive fast crashes before giving up (crash loop). */
+const MAX_FAST_CRASHES = 5
+/** Don't evaluate liveness until the node has had time to bootstrap. */
+const LIVENESS_GRACE_MS = 5 * 60_000
+/** 0 peers for this long (with internet up) ⇒ wedged. */
+const ZERO_PEERS_LIMIT_MS = 5 * 60_000
+
+interface SupervisorState {
+  consecutiveFastCrashes: number
+  notBeforeMs: number
+  crashLoop: boolean
+  lastStartMs: number | null
+  zeroPeersSinceMs: number | null
+  wedgeRestarts: number
+}
+
+const state: SupervisorState = {
+  consecutiveFastCrashes: 0,
+  notBeforeMs: 0,
+  crashLoop: false,
+  lastStartMs: null,
+  zeroPeersSinceMs: null,
+  wedgeRestarts: 0,
+}
+
+/** May the keep-alive loop attempt a (re)start right now? */
+export function canAttemptStart(nowMs: number): boolean {
+  return !state.crashLoop && nowMs >= state.notBeforeMs
+}
+
+export function recordStart(nowMs: number): void {
+  state.lastStartMs = nowMs
+  state.zeroPeersSinceMs = null
+}
+
+/** Call when a Bee run ends. Uptime decides crash accounting. */
+export function recordExit(nowMs: number): void {
+  const uptime = state.lastStartMs === null ? Number.POSITIVE_INFINITY : nowMs - state.lastStartMs
+
+  if (uptime >= FAST_CRASH_MS) {
+    // Healthy run (or a deliberate wedge restart) — clean slate.
+    state.consecutiveFastCrashes = 0
+    state.notBeforeMs = 0
+
+    return
+  }
+
+  state.consecutiveFastCrashes++
+
+  if (state.consecutiveFastCrashes >= MAX_FAST_CRASHES) {
+    state.crashLoop = true
+    logger.error(
+      `bee crashed ${state.consecutiveFastCrashes} times in a row (uptime < ${FAST_CRASH_MS / 1000}s) — ` +
+        'giving up on automatic restarts. Use Restart in the app to try again.',
+    )
+
+    return
+  }
+
+  const delay = Math.min(BASE_RESTART_DELAY_MS * 2 ** state.consecutiveFastCrashes, MAX_RESTART_DELAY_MS)
+  state.notBeforeMs = nowMs + delay
+  logger.warn(
+    `bee exited after ${Math.round(uptime / 1000)}s (fast crash ${state.consecutiveFastCrashes}/${MAX_FAST_CRASHES}) — ` +
+      `next restart in ${Math.round(delay / 1000)}s`,
+  )
+}
+
+/** User asked for a fresh start (tray Restart / POST /restart) — forgive everything. */
+export function resetCrashLoop(): void {
+  state.consecutiveFastCrashes = 0
+  state.notBeforeMs = 0
+  state.crashLoop = false
+}
+
+export interface LivenessProbes {
+  /** Connected peer count from the local node, or null when unreachable. */
+  getPeerCount: () => Promise<number | null>
+  /** Cheap external reachability check. */
+  hasInternet: () => Promise<boolean>
+}
+
+/**
+ * Evaluate the wedge condition. Returns true when the caller should kill Bee
+ * (the keep-alive loop then relaunches it). Callers invoke this on their tick
+ * only while Bee is running.
+ */
+export async function shouldRestartForWedge(nowMs: number, probes: LivenessProbes): Promise<boolean> {
+  if (state.lastStartMs === null || nowMs - state.lastStartMs < LIVENESS_GRACE_MS) return false
+
+  const peers = await probes.getPeerCount()
+
+  // API unreachable is a different failure (crash detection handles a dead
+  // process); only a live API reporting zero peers arms the wedge timer.
+  if (peers === null || peers > 0) {
+    state.zeroPeersSinceMs = null
+
+    return false
+  }
+
+  if (state.zeroPeersSinceMs === null) {
+    state.zeroPeersSinceMs = nowMs
+
+    return false
+  }
+
+  if (nowMs - state.zeroPeersSinceMs < ZERO_PEERS_LIMIT_MS) return false
+
+  if (!(await probes.hasInternet())) {
+    // Host is offline — nothing a restart can fix; keep waiting.
+    return false
+  }
+
+  state.wedgeRestarts++
+  state.zeroPeersSinceMs = null
+  logger.error(
+    `bee wedged: 0 peers for ${ZERO_PEERS_LIMIT_MS / 60_000}m with internet up — restarting (wedge restart #${state.wedgeRestarts})`,
+  )
+
+  return true
+}
+
+export function getSupervisorStatus(): { crashLoop: boolean; consecutiveFastCrashes: number; wedgeRestarts: number } {
+  return {
+    crashLoop: state.crashLoop,
+    consecutiveFastCrashes: state.consecutiveFastCrashes,
+    wedgeRestarts: state.wedgeRestarts,
+  }
+}

--- a/test/supervisor.spec.ts
+++ b/test/supervisor.spec.ts
@@ -1,0 +1,123 @@
+jest.mock('env-paths', () =>
+  jest.fn().mockImplementation(() => ({
+    data: 'test/data',
+    config: 'test/data',
+    cache: 'test/data',
+    log: 'test/data',
+    temp: 'test/data',
+  })),
+)
+
+import {
+  canAttemptStart,
+  getSupervisorStatus,
+  recordExit,
+  recordStart,
+  resetCrashLoop,
+  shouldRestartForWedge,
+} from '../src/supervisor'
+
+const MIN = 60_000
+
+function probes(peerCount: number | null, internet = true) {
+  return {
+    getPeerCount: async () => peerCount,
+    hasInternet: async () => internet,
+  }
+}
+
+describe('supervisor', () => {
+  beforeEach(() => resetCrashLoop())
+
+  test('healthy run resets crash accounting', () => {
+    let t = 0
+    recordStart(t)
+    recordExit((t += 2 * MIN)) // uptime 2min = healthy
+    expect(canAttemptStart(t)).toBe(true)
+    expect(getSupervisorStatus().consecutiveFastCrashes).toBe(0)
+  })
+
+  test('fast crashes back off exponentially', () => {
+    let t = 0
+    recordStart(t)
+    recordExit((t += 5_000)) // crash 1 → wait 20s
+    expect(canAttemptStart(t + 10_000)).toBe(false)
+    expect(canAttemptStart(t + 21_000)).toBe(true)
+
+    recordStart((t += 21_000))
+    recordExit((t += 5_000)) // crash 2 → wait 40s
+    expect(canAttemptStart(t + 30_000)).toBe(false)
+    expect(canAttemptStart(t + 41_000)).toBe(true)
+  })
+
+  test('a long run after crashes resets the ladder', () => {
+    let t = 0
+    recordStart(t)
+    recordExit((t += 5_000)) // crash 1
+    recordStart((t += 30_000))
+    recordExit((t += 2 * MIN)) // healthy
+    expect(getSupervisorStatus().consecutiveFastCrashes).toBe(0)
+    expect(canAttemptStart(t)).toBe(true)
+  })
+
+  test('5 consecutive fast crashes trip the crash loop; reset forgives', () => {
+    let t = 0
+
+    for (let i = 0; i < 5; i++) {
+      recordStart(t)
+      recordExit((t += 5_000))
+      t += 10 * MIN // wait out any backoff
+    }
+    expect(getSupervisorStatus().crashLoop).toBe(true)
+    expect(canAttemptStart(t)).toBe(false)
+
+    resetCrashLoop()
+    expect(getSupervisorStatus().crashLoop).toBe(false)
+    expect(canAttemptStart(t)).toBe(true)
+  })
+
+  describe('wedge detection', () => {
+    test('no restart during warmup grace', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(2 * MIN, probes(0))).toBe(false)
+    })
+
+    test('0 peers must persist past the limit before restarting', async () => {
+      recordStart(0)
+      // Past grace, first zero-peers observation only arms the timer
+      expect(await shouldRestartForWedge(6 * MIN, probes(0))).toBe(false)
+      // Still within the 5-minute window
+      expect(await shouldRestartForWedge(8 * MIN, probes(0))).toBe(false)
+      // Past the window with internet up → restart
+      expect(await shouldRestartForWedge(12 * MIN, probes(0))).toBe(true)
+    })
+
+    test('peers recovering disarms the timer', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(6 * MIN, probes(0))).toBe(false)
+      expect(await shouldRestartForWedge(8 * MIN, probes(30))).toBe(false) // recovered
+      expect(await shouldRestartForWedge(14 * MIN, probes(0))).toBe(false) // re-arms fresh
+    })
+
+    test('no internet → no restart (nothing to fix)', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(6 * MIN, probes(0, false))).toBe(false)
+      expect(await shouldRestartForWedge(12 * MIN, probes(0, false))).toBe(false)
+    })
+
+    test('unreachable API is not a wedge (crash detection owns that)', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(6 * MIN, probes(null))).toBe(false)
+      expect(await shouldRestartForWedge(12 * MIN, probes(null))).toBe(false)
+    })
+
+    test('after a wedge restart the timer starts clean', async () => {
+      recordStart(0)
+      await shouldRestartForWedge(6 * MIN, probes(0))
+      expect(await shouldRestartForWedge(12 * MIN, probes(0))).toBe(true)
+      // New run
+      recordStart(13 * MIN)
+      expect(await shouldRestartForWedge(19 * MIN, probes(0))).toBe(false) // arms only
+    })
+  })
+})

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -54,6 +54,8 @@ export interface Status {
   address?: string
   /** True when the user intentionally stopped Bee via the tray menu. */
   userStopped?: boolean
+  /** True when Bee crashed repeatedly and automatic restarts are paused (#94). */
+  crashLoop?: boolean
 }
 
 export interface Peers {

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useDisconnect } from 'wagmi'
 import { weiToDai } from '../api/bee'
-import { useBeeHealth, usePeers, useStamps, useStatus, useWallet } from '../api/queries'
+import { useBeeHealth, usePeers, useRestart, useStamps, useStatus, useWallet } from '../api/queries'
 import { useInboxPolling } from '../hooks/useInboxPolling'
 import { primeCricketAudio } from '../lib/cricket'
 import { loadReadCursors, loadThreads, totalUnread } from '../notify/messages'
@@ -122,6 +122,7 @@ export default function Layout() {
   const { isError: beeOffline, isPending: beeChecking, isSuccess: beeOnline } = useBeeHealth()
   const { data: peers } = usePeers()
   const { data: status } = useStatus()
+  const restartBee = useRestart()
   const { data: stamps, isSuccess: stampsLoaded } = useStamps()
   const { data: wallet, isSuccess: walletLoaded } = useWallet()
   const { devMode, onboardingCompleted, setOnboardingCompleted } = useAppStore()
@@ -339,8 +340,28 @@ export default function Layout() {
             </div>
           )}
 
+          {/* Crash loop — the supervisor gave up restarting Bee (#94) */}
+          {status?.crashLoop && !showOnboarding && (
+            <div
+              className="flex items-center gap-2 px-4 py-2.5 text-xs shrink-0"
+              style={{ backgroundColor: 'rgba(239,68,68,0.1)', borderBottom: '1px solid rgba(239,68,68,0.2)' }}
+            >
+              <AlertTriangle size={13} className="shrink-0" style={{ color: '#ef4444' }} />
+              <span style={{ color: '#ef4444' }}>
+                Bee keeps crashing — automatic restarts paused. Check the Logs tab.{' '}
+                <button
+                  onClick={() => restartBee.mutate()}
+                  className="underline font-semibold"
+                  style={{ color: '#ef4444' }}
+                >
+                  Try again
+                </button>
+              </span>
+            </div>
+          )}
+
           {/* Bee down — only shown after it was previously online */}
-          {showDown && !showOnboarding && (
+          {showDown && !status?.crashLoop && !showOnboarding && (
             <div
               className="flex items-center gap-2 px-4 py-2.5 text-xs shrink-0"
               style={{ backgroundColor: 'rgba(239,68,68,0.1)', borderBottom: '1px solid rgba(239,68,68,0.2)' }}


### PR DESCRIPTION
Implements all three parts of #94:

- **A. Crash backoff + crash-loop guard** — exponential restart delay (10s→5min cap), stop after 5 fast crashes with a red UI banner + Try again (resets via POST /restart)
- **B. Fetch timeouts** — `fetchWithTimeout` on chequebook monitor + /bee-api proxy (5min budget for big transfers)
- **C. Sleep/wake wedge detection** — 0 peers for 5min (post-grace) with internet up → automatic Bee bounce via new `BeeManager.kill()` (preserves run intention). Motivated by the 2026-07-15 live incident (40min wedge, manual restart → 51 peers in 2min).

`src/supervisor.ts` = pure state machine, injectable probes, **10 unit tests** (backoff ladder, loop trip/reset, all wedge paths incl. no-internet and API-unreachable non-cases).

Verified: 38/38 backend tests, 30/30 UI, lint 0 errors, types clean.

## Test notes (next develop build)
1. Normal run: no behavior change; after laptop sleep overnight, node should self-heal within ~5min of wake (look for 'bee wedged … restarting' in nook.log)
2. Crash loop: rename the bee binary → launch → watch backoff lines in log, red banner after 5 attempts, Try again recovers after restoring the binary

Closes #94