### PR TITLE
feat(upload): honest two-stage progress + retrievability verification (#92, #93)

### DIFF
--- a/ui/src/api/bee.ts
+++ b/ui/src/api/bee.ts
@@ -411,6 +411,20 @@ export const beeApi = {
   getTag: async (uid: number): Promise<UploadTag> => beeRequest<UploadTag>(`/tags/${uid}`),
 
   /**
+   * Re-push content to the network from this node's local store (#93 fix
+   * action). Bee stewardship PUT traverses the reference and re-uploads every
+   * chunk with a fresh stamp — the one-call cure when the network can't serve
+   * content this node still holds.
+   */
+  reuploadToNetwork: async (reference: string, stampId: string): Promise<void> => {
+    await beeRequest(`/stewardship/${reference}`, {
+      method: 'PUT',
+      headers: { 'swarm-postage-batch-id': stampId },
+      signal: AbortSignal.timeout(120_000),
+    })
+  },
+
+  /**
    * Is this reference retrievable from the NETWORK (#93)? One stewardship call —
    * Bee attempts an actual retrieval, so treat it as expensive: on-demand and
    * slow-cadence only, never in fast polls.

--- a/ui/src/api/bee.ts
+++ b/ui/src/api/bee.ts
@@ -46,6 +46,92 @@ async function xhrUpload(
   })
 }
 
+/**
+ * Bee upload-session tag (#92). Counters (all in chunks):
+ * `split` = produced by the splitter, `seen` = already known to the network
+ * (dedup), `sent`/`synced` = pushed / receipt-confirmed. For a deferred upload,
+ * `(seen + synced) / split` is the true network-propagation progress — the XHR
+ * progress bar only measures bytes reaching the LOCAL node.
+ */
+export interface UploadTag {
+  uid: number
+  split: number
+  seen: number
+  sent: number
+  synced: number
+}
+
+/**
+ * Poll a tag until the upload is fully propagated (#92). swarm-cli's pattern:
+ * poll every second, and RESET the patience counter whenever progress advances,
+ * so slow networks don't time out spuriously — only genuine stalls do.
+ * Resolves `{ complete: false }` on stall instead of throwing: the content is
+ * safe on the local node and the background pusher keeps working; the caller
+ * should proceed with a soft warning, not fail the upload.
+ */
+export async function waitForTagPropagation(
+  uid: number,
+  onProgress?: (pct: number) => void,
+  opts: { pollMs?: number; maxStalledPolls?: number } = {},
+): Promise<{ complete: boolean; tag: UploadTag | null }> {
+  const pollMs = opts.pollMs ?? 1000
+  const maxStalledPolls = opts.maxStalledPolls ?? 60
+  let best = -1
+  let stalled = 0
+  let tag: UploadTag | null = null
+
+  while (stalled < maxStalledPolls) {
+    try {
+      tag = await beeRequest<UploadTag>(`/tags/${uid}`)
+      const done = tag.seen + tag.synced
+
+      if (tag.split > 0) {
+        onProgress?.(Math.min(Math.round((done / tag.split) * 100), 100))
+
+        if (done >= tag.split) return { complete: true, tag }
+      }
+
+      if (done > best) {
+        best = done
+        stalled = 0
+      } else {
+        stalled++
+      }
+    } catch {
+      stalled++
+    }
+    await new Promise(r => setTimeout(r, pollMs))
+  }
+
+  return { complete: false, tag }
+}
+
+/**
+ * Confirm a reference is retrievable from the network, with patience (#93).
+ * Direct uploads should pass quickly; a just-pushed ref can lag a few seconds.
+ * Returns false after `attempts` failures — callers show a soft warning, they
+ * don't fail the operation (the content may still propagate).
+ */
+export async function waitForRetrievable(
+  reference: string,
+  opts: { attempts?: number; delayMs?: number } = {},
+): Promise<boolean> {
+  const attempts = opts.attempts ?? 3
+  const delayMs = opts.delayMs ?? 4000
+
+  for (let i = 0; i < attempts; i++) {
+    try {
+      if (await beeApi.checkRetrievable(reference)) return true
+    } catch {
+      // stewardship endpoint unavailable/timeout — retry
+    }
+
+    if (i < attempts - 1) await new Promise(r => setTimeout(r, delayMs))
+  }
+
+  return false
+}
+
 async function beeRequest<T>(path: string, options?: RequestInit): Promise<T> {
   const url = `${getBeeUrl()}${path}`
   const response = await fetch(url, options)
@@ -314,11 +400,35 @@ export const beeApi = {
   diluteStamp: async (id: string, depth: number) =>
     beeRequest<{ batchID: string }>(`/stamps/dilute/${id}/${depth}`, { method: 'PATCH' }),
 
+  /** Create an upload-session tag (#92). Pass its uid to an upload to track network propagation. */
+  createTag: async (): Promise<UploadTag> =>
+    beeRequest<UploadTag>('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    }),
+
+  getTag: async (uid: number): Promise<UploadTag> => beeRequest<UploadTag>(`/tags/${uid}`),
+
+  /**
+   * Is this reference retrievable from the NETWORK (#93)? One stewardship call —
+   * Bee attempts an actual retrieval, so treat it as expensive: on-demand and
+   * slow-cadence only, never in fast polls.
+   */
+  checkRetrievable: async (reference: string): Promise<boolean> => {
+    const res = await beeRequest<{ isRetrievable: boolean }>(`/stewardship/${reference}`, {
+      signal: AbortSignal.timeout(30_000),
+    })
+
+    return res.isRetrievable
+  },
+
   uploadFileWithProgress: async (
     file: File,
     stampId: string,
     onProgress?: (pct: number) => void,
     deferred = true,
+    tagUid?: number,
   ): Promise<UploadResult> =>
     xhrUpload(
       `${getBeeUrl()}/bzz`,
@@ -328,6 +438,7 @@ export const beeApi = {
         'swarm-deferred-upload': deferred ? 'true' : 'false',
         'Content-Type': file.type || 'application/octet-stream',
         'Content-Disposition': `inline; filename="${encodeURIComponent(file.name)}"`,
+        ...(tagUid !== undefined ? { 'swarm-tag': String(tagUid) } : {}),
       },
       onProgress,
     ),
@@ -335,7 +446,7 @@ export const beeApi = {
   uploadCollectionWithProgress: async (
     entries: FileEntry[],
     stampId: string,
-    options?: { indexDocument?: string; errorDocument?: string; deferred?: boolean },
+    options?: { indexDocument?: string; errorDocument?: string; deferred?: boolean; tagUid?: number },
     onProgress?: (pct: number) => void,
   ): Promise<UploadResult> => {
     const tar = await createTar(entries)
@@ -350,6 +461,8 @@ export const beeApi = {
     if (options?.indexDocument) headers['swarm-index-document'] = options.indexDocument
 
     if (options?.errorDocument) headers['swarm-error-document'] = options.errorDocument
+
+    if (options?.tagUid !== undefined) headers['swarm-tag'] = String(options.tagUid)
 
     return xhrUpload(`${getBeeUrl()}/bzz`, tar as XMLHttpRequestBodyInit, headers, onProgress)
   },

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -60,6 +60,12 @@ interface ShareModalProps {
   onRepublish?: () => void
   /** Latest public wrapper ref after a metadata refresh (#93 health checks). */
   onWrapperRef?: (ref: string) => void
+  /**
+   * Authoritative grantee count (including owner), reported whenever the list
+   * is loaded from the node. Self-heals the cached count on the drive card —
+   * grant/revoke math can drift when operations race the async list load.
+   */
+  onGranteeCount?: (n: number) => void
 }
 
 function isValidPublicKey(key: string): boolean {
@@ -89,6 +95,7 @@ export default function ShareModal({
   republishMsg,
   onRepublish,
   onWrapperRef,
+  onGranteeCount,
 }: ShareModalProps) {
   const { signer } = useDerivedKey()
   const { data: walletClient } = useWalletClient()
@@ -198,7 +205,11 @@ export default function ShareModal({
     setLoadedGrantees(true)
     serverApi
       .getGrantees(granteeRef)
-      .then(result => setGrantees(result.grantees))
+      .then(result => {
+        setGrantees(result.grantees)
+        // Server list is the truth — heal the drive card's cached count.
+        onGranteeCount?.(result.grantees.length)
+      })
       .catch(() => setGrantees([]))
   }
 

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -208,7 +208,10 @@ export default function ShareModal({
       .then(result => {
         setGrantees(result.grantees)
         // Server list is the truth — heal the drive card's cached count.
-        onGranteeCount?.(result.grantees.length)
+        // Count OTHER people explicitly: depending on how a drive was created
+        // its list may or may not contain the owner's own key, so raw list
+        // length is off-by-one for some drives. Stored convention: others + 1.
+        onGranteeCount?.(result.grantees.filter(g => !isMyKey(g)).length + 1)
       })
       .catch(() => setGrantees([]))
   }
@@ -360,7 +363,7 @@ export default function ShareModal({
       onUpdate({
         granteeRef: result.ref,
         historyRef: result.historyRef,
-        granteeCount: grantees.length + 1,
+        granteeCount: [...grantees, key].filter(g => !isMyKey(g)).length + 1,
       })
 
       // Refresh from localStorage so a newly-added contact is matched for the
@@ -408,7 +411,7 @@ export default function ShareModal({
       onUpdate({
         granteeRef: result.ref,
         historyRef: result.historyRef,
-        granteeCount: grantees.length - 1,
+        granteeCount: grantees.filter(g => g !== key && !isMyKey(g)).length + 1,
         keyRotated: true,
       })
     } catch (err) {

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from 'react'
 import { getWalletClient, switchChain } from '@wagmi/core'
 import { useWalletClient } from 'wagmi'
 
-import { topicFromString } from '../api/bee'
+import { topicFromString, waitForRetrievable } from '../api/bee'
 import { serverApi } from '../api/server'
 import { bytesToHex, hexToBytes } from '../lib/hex'
 import { useDerivedKey } from '../hooks/useDerivedKey'
@@ -435,6 +435,13 @@ export default function ShareModal({
     const wrapperResult = await serverApi.uploadRawBytes(stampId, wrapper)
 
     await serverApi.createFeedUpdate(topic, wrapperResult.reference, stampId)
+
+    // #93: never hand out a link to content the network can't serve. The
+    // wrapper is what the recipient's feed read resolves first — verify it's
+    // actually retrievable (uploads are direct, so this should pass fast).
+    if (!(await waitForRetrievable(wrapperResult.reference, { attempts: 3, delayMs: 4000 }))) {
+      throw new Error("Content hasn't reached the network yet — wait a moment and try sharing again.")
+    }
 
     return buildShareLink({
       feedTopic: topic,

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -58,6 +58,8 @@ interface ShareModalProps {
   republishMsg?: string | null
   /** Re-encrypt + re-upload this drive's files under the current key. */
   onRepublish?: () => void
+  /** Latest public wrapper ref after a metadata refresh (#93 health checks). */
+  onWrapperRef?: (ref: string) => void
 }
 
 function isValidPublicKey(key: string): boolean {
@@ -86,6 +88,7 @@ export default function ShareModal({
   republishing,
   republishMsg,
   onRepublish,
+  onWrapperRef,
 }: ShareModalProps) {
   const { signer } = useDerivedKey()
   const { data: walletClient } = useWalletClient()
@@ -442,6 +445,7 @@ export default function ShareModal({
     if (!(await waitForRetrievable(wrapperResult.reference, { attempts: 3, delayMs: 4000 }))) {
       throw new Error("Content hasn't reached the network yet — wait a moment and try sharing again.")
     }
+    onWrapperRef?.(wrapperResult.reference)
 
     return buildShareLink({
       feedTopic: topic,

--- a/ui/src/hooks/useDriveMetadata.ts
+++ b/ui/src/hooks/useDriveMetadata.ts
@@ -34,6 +34,13 @@ export interface LocalDriveMetadata {
    * signer: the drive can be re-anchored from bpub to this wpub.
    */
   creatorWpub?: string
+  /**
+   * Latest metadata-feed WRAPPER reference (public bytes). This is the first
+   * thing a share recipient resolves (feed → wrapper → metadata), and — unlike
+   * the ACT-encrypted file refs — it's a real content address that stewardship
+   * can verify. Used by the drive-health check (#93).
+   */
+  lastWrapperRef?: string
 }
 
 function load(): Record<string, LocalDriveMetadata> {

--- a/ui/src/hooks/useUpload.ts
+++ b/ui/src/hooks/useUpload.ts
@@ -1,4 +1,4 @@
-import { beeApi, topicFromString } from '../api/bee'
+import { beeApi, topicFromString, waitForTagPropagation } from '../api/bee'
 import { serverApi } from '../api/server'
 import { detectIndexDocument, type FileEntry } from '../utils/directory'
 import { useUploadHistory } from './useUploadHistory'
@@ -84,7 +84,7 @@ export function useUpload() {
     // even after the stamp reports as usable via REST.
     let currentHistoryRef = actHistoryRef
 
-    async function doUpload(attempt: number): Promise<{ reference: string; historyAddress?: string }> {
+    async function doUpload(attempt: number): Promise<{ reference: string; historyAddress?: string; tagUid?: number }> {
       if (attempt > 1) {
         onPhase?.(`Finalising storage… (retry ${attempt - 1})`)
         await new Promise(r => setTimeout(r, 10000))
@@ -105,31 +105,48 @@ export function useUpload() {
         return beeApi.uploadCollectionWithACT(entries, driveId, currentHistoryRef, opts, pct => onProgress?.(pct))
       }
 
-      // Regular (non-encrypted) upload
-      if (type === 'file') {
-        const res = await beeApi.uploadFileWithProgress(entries[0].file, driveId, pct => onProgress?.(pct), true)
+      // Regular (non-encrypted) upload — deferred, so bytes land on the LOCAL
+      // node first. A tag (#92) tracks the real network propagation afterwards.
+      let tagUid: number | undefined
 
-        return { reference: res.reference }
+      try {
+        tagUid = (await beeApi.createTag()).uid
+      } catch {
+        // Tags unavailable — upload proceeds without stage-2 progress.
+      }
+
+      if (type === 'file') {
+        const res = await beeApi.uploadFileWithProgress(
+          entries[0].file,
+          driveId,
+          pct => onProgress?.(pct),
+          true,
+          tagUid,
+        )
+
+        return { reference: res.reference, tagUid }
       }
 
       const autoIndex = indexDocument ?? detectIndexDocument(entries) ?? 'index.html'
       const opts =
         type === 'website'
-          ? { indexDocument: autoIndex, errorDocument: '404.html', deferred: true }
-          : { deferred: true }
+          ? { indexDocument: autoIndex, errorDocument: '404.html', deferred: true, tagUid }
+          : { deferred: true, tagUid }
       const res = await beeApi.uploadCollectionWithProgress(entries, driveId, opts, pct => onProgress?.(pct))
 
-      return { reference: res.reference }
+      return { reference: res.reference, tagUid }
     }
 
     let reference!: string
     let uploadHistoryAddress: string | undefined
+    let uploadTagUid: number | undefined
 
     for (let attempt = 1; attempt <= 8; attempt++) {
       try {
         const result = await doUpload(attempt)
         reference = result.reference
         uploadHistoryAddress = result.historyAddress
+        uploadTagUid = result.tagUid
 
         // Update history ref for next upload in same session
         if (uploadHistoryAddress) currentHistoryRef = uploadHistoryAddress
@@ -142,6 +159,21 @@ export function useUpload() {
 
         if (attempt === 8) throw err
         // stamp issuer may not be loaded yet — retry
+      }
+    }
+
+    // Stage 2 (#92): the XHR bar only measured bytes reaching the LOCAL node.
+    // For deferred uploads, follow the tag until the content is actually on the
+    // network. A stall is a soft outcome — the background pusher keeps working,
+    // so warn in the phase text but never fail the upload here.
+    if (uploadTagUid !== undefined && !encrypted) {
+      onPhase?.('Propagating to network…')
+      onProgress?.(0)
+      const { complete } = await waitForTagPropagation(uploadTagUid, pct => onProgress?.(pct))
+
+      if (!complete) {
+        onPhase?.('Still propagating in the background…')
+        await new Promise(r => setTimeout(r, 1500))
       }
     }
 

--- a/ui/src/lib/republish.ts
+++ b/ui/src/lib/republish.ts
@@ -32,10 +32,12 @@ export interface RepublishDeps {
   onRecordUpdate: (id: string, changes: Partial<UploadRecord>) => void
   /** Persist the drive's new latest history ref. */
   onHistoryUpdate: (historyRef: string) => void
+  /** Latest public wrapper ref after the metadata rebuild (#93 health checks). */
+  onWrapperRef?: (ref: string) => void
 }
 
 export async function republishDrive(deps: RepublishDeps): Promise<void> {
-  const { driveId, records, actPublisher, onProgress, onRecordUpdate, onHistoryUpdate } = deps
+  const { driveId, records, actPublisher, onProgress, onRecordUpdate, onHistoryUpdate, onWrapperRef } = deps
 
   // Only single files are round-trippable via ACT download/upload here.
   // (Folders/websites are collections — re-publishing those is a follow-up.)
@@ -76,4 +78,5 @@ export async function republishDrive(deps: RepublishDeps): Promise<void> {
 
   await serverApi.createFeedUpdate(topic, wrapperResult.reference, driveId)
   onHistoryUpdate(uploaded.historyRef)
+  onWrapperRef?.(wrapperResult.reference)
 }

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1137,16 +1137,28 @@ function DriveCard({
   const usagePct = Math.min(fillRatio * 100, 100)
   const utilizationPct = Math.round(fillRatio * 100)
   const isFull = fillRatio >= 1
-  // #93: slow-cadence health check for SHARED drives — can the network serve
-  // the newest file? Stewardship triggers a real retrieval, so this is gated to
-  // shared+encrypted drives only, one file, refreshed at most hourly.
+  // #93: slow-cadence health check for SHARED drives. Target = the PUBLIC
+  // metadata wrapper (the first hop recipients resolve) — ACT file refs are
+  // encrypted pointers that stewardship cannot verify, so drives without a
+  // recorded wrapper ref are simply not checked.
   const isShared = Boolean(encrypted && granteeCount && granteeCount > 1)
-  const newestRef = records.length > 0 ? records[records.length - 1].hash : undefined
   const { data: healthOk } = useQuery({
-    queryKey: ['drive-health', stamp.batchID, newestRef],
-    queryFn: async () => beeApi.checkRetrievable(newestRef!),
-    enabled: isShared && Boolean(newestRef) && stamp.usable,
-    staleTime: 60 * 60 * 1000,
+    queryKey: ['drive-health', stamp.batchID, wrapperRef],
+    // Two-strike rule: bee's IsRetrievable retrieves ONLY from the network
+    // (steward netGetter — bypasses the local store), which is the right
+    // question but flaky for freshly-pushed content on a light node. Only
+    // report unhealthy when two checks ~25s apart BOTH fail.
+    queryFn: async () => {
+      if (await beeApi.checkRetrievable(wrapperRef!)) return true
+      await new Promise(r => setTimeout(r, 25_000))
+
+      return beeApi.checkRetrievable(wrapperRef!)
+    },
+    enabled: isShared && Boolean(wrapperRef) && stamp.usable,
+    // Red verdicts re-check every 10 minutes so the pill clears itself once
+    // the network catches up; healthy drives only re-check hourly.
+    refetchInterval: query => (query.state.data === false ? 10 * 60 * 1000 : 60 * 60 * 1000),
+    staleTime: 10 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
     retry: false,
     refetchOnWindowFocus: false,

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -2473,6 +2473,7 @@ export default function Drive() {
                   .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
                 onClose={() => setShowShareModal(null)}
                 onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
+                onGranteeCount={n => driveMetadata.update(showShareModal, { granteeCount: n })}
                 onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                   driveMetadata.update(showShareModal, {
                     granteeRef,
@@ -3036,6 +3037,7 @@ export default function Drive() {
                 .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
               onClose={() => setShowShareModal(null)}
               onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
+              onGranteeCount={n => driveMetadata.update(showShareModal, { granteeCount: n })}
               onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                 driveMetadata.update(showShareModal, {
                   granteeRef,

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   ArrowLeft,
   Check,
   ChevronDown,
@@ -26,7 +27,7 @@ import {
   Users,
   X,
 } from 'lucide-react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import React, { useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useAccount } from 'wagmi'
@@ -41,6 +42,8 @@ import {
   SIZE_PRESETS,
   stampFillRatio,
   topicFromString,
+  waitForRetrievable,
+  waitForTagPropagation,
   type Stamp,
 } from '../api/bee'
 import { serverApi } from '../api/server'
@@ -1131,6 +1134,21 @@ function DriveCard({
   const usagePct = Math.min(fillRatio * 100, 100)
   const utilizationPct = Math.round(fillRatio * 100)
   const isFull = fillRatio >= 1
+  // #93: slow-cadence health check for SHARED drives — can the network serve
+  // the newest file? Stewardship triggers a real retrieval, so this is gated to
+  // shared+encrypted drives only, one file, refreshed at most hourly.
+  const isShared = Boolean(encrypted && granteeCount && granteeCount > 1)
+  const newestRef = records.length > 0 ? records[records.length - 1].hash : undefined
+  const { data: healthOk } = useQuery({
+    queryKey: ['drive-health', stamp.batchID, newestRef],
+    queryFn: async () => beeApi.checkRetrievable(newestRef!),
+    enabled: isShared && Boolean(newestRef) && stamp.usable,
+    staleTime: 60 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+  const showHealthWarning = isShared && healthOk === false
   const ttlDays = stamp.batchTTL / 86400
   // Critical = days-pill turns red. Matches Figma's 'red at ≤7 days' threshold.
   const isCriticalTtl = stamp.usable && ttlDays > 0 && ttlDays <= 7
@@ -1275,6 +1293,18 @@ function DriveCard({
             >
               <Lock size={12} />
               Encrypted{granteeCount && granteeCount > 1 ? ` · ${granteeCount - 1} shared` : ''}
+            </span>
+          )}
+
+          {/* #93: newest shared file isn't retrievable from the network */}
+          {showHealthWarning && (
+            <span
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0"
+              style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
+              title="The newest file in this drive isn't retrievable from the network right now — recipients may not be able to open it. Re-publish can push it again."
+            >
+              <AlertTriangle size={11} />
+              Availability
             </span>
           )}
 
@@ -1476,7 +1506,9 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
 
       let currentHistoryRef = actHistoryRef
 
-      async function doUpload(attempt: number): Promise<{ reference: string; historyAddress?: string }> {
+      async function doUpload(
+        attempt: number,
+      ): Promise<{ reference: string; historyAddress?: string; tagUid?: number }> {
         if (attempt > 1) {
           setPhase(`Finalising storage… (retry ${attempt - 1})`)
           await new Promise(r => setTimeout(r, 5000))
@@ -1494,27 +1526,45 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
           )
         }
 
-        if (type === 'file') {
-          const res = await beeApi.uploadFileWithProgress(entries[0].file, driveId, pct => setProgress(pct))
+        // Regular (deferred) upload — a tag (#92) tracks network propagation
+        // after the XHR bar (which only measures bytes to the LOCAL node).
+        let tagUid: number | undefined
 
-          return { reference: res.reference }
+        try {
+          tagUid = (await beeApi.createTag()).uid
+        } catch {
+          // Tags unavailable — proceed without stage-2 progress.
         }
 
-        const res = await beeApi.uploadCollectionWithProgress(uploadEntries, driveId, { indexDocument }, pct =>
+        if (type === 'file') {
+          const res = await beeApi.uploadFileWithProgress(
+            entries[0].file,
+            driveId,
+            pct => setProgress(pct),
+            true,
+            tagUid,
+          )
+
+          return { reference: res.reference, tagUid }
+        }
+
+        const res = await beeApi.uploadCollectionWithProgress(uploadEntries, driveId, { indexDocument, tagUid }, pct =>
           setProgress(pct),
         )
 
-        return { reference: res.reference }
+        return { reference: res.reference, tagUid }
       }
 
       let reference!: string
       let uploadHistoryAddress: string | undefined
+      let uploadTagUid: number | undefined
 
       for (let attempt = 1; attempt <= 4; attempt++) {
         try {
           const result = await doUpload(attempt)
           reference = result.reference
           uploadHistoryAddress = result.historyAddress
+          uploadTagUid = result.tagUid
 
           if (uploadHistoryAddress) {
             currentHistoryRef = uploadHistoryAddress
@@ -1524,6 +1574,21 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
         } catch (err) {
           if (attempt === 4) throw err
         }
+      }
+
+      if (encrypted) {
+        // #93: encrypted content is direct-uploaded — confirm the network can
+        // actually serve it (grantees depend on it). Soft outcome: on failure
+        // keep going (pusher may still finish); the hard gate is in ShareModal.
+        setPhase('Confirming availability…')
+        await waitForRetrievable(reference, { attempts: 2, delayMs: 4000 })
+      } else if (uploadTagUid !== undefined) {
+        // #92 stage 2: follow the tag until the content is on the network.
+        setPhase('Propagating to network…')
+        setProgress(0)
+        const { complete } = await waitForTagPropagation(uploadTagUid, pct => setProgress(pct))
+
+        if (!complete) setPhase('Still propagating in the background…')
       }
 
       setProgress(null)

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1078,6 +1078,8 @@ interface DriveCardProps {
   customName?: string
   encrypted?: boolean
   granteeCount?: number
+  /** Latest public metadata-wrapper ref — the health-check target (#93). */
+  wrapperRef?: string
   onOpen: (folderId?: string) => void
   onExtend: () => void
   onShare?: () => void
@@ -1109,6 +1111,7 @@ function DriveCard({
   onSetENS,
   encrypted,
   granteeCount,
+  wrapperRef,
   onShare,
   onMoveToFolder,
 }: DriveCardProps) {
@@ -1301,7 +1304,7 @@ function DriveCard({
             <span
               className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0"
               style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
-              title="The newest file in this drive isn't retrievable from the network right now — recipients may not be able to open it. Re-publish can push it again."
+              title="This drive's shared metadata isn't retrievable from the network right now — recipients may not be able to open the drive. Sharing again (or re-publish) pushes it back."
             >
               <AlertTriangle size={11} />
               Availability
@@ -1465,6 +1468,8 @@ interface AddFileProps {
   onDone: () => void
   onAdd: (record: UploadRecord) => void
   onActHistoryUpdate?: (historyRef: string) => void
+  /** Latest public wrapper ref after the metadata feed update (#93 health checks). */
+  onWrapperRef?: (ref: string) => void
 }
 
 function generateFolderIndex(name: string, entries: FileEntry[]): FileEntry {
@@ -1481,7 +1486,15 @@ ${rows}
   return { path: '_index.html', file: new FileClass([html], '_index.html', { type: 'text/html' }) }
 }
 
-function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActHistoryUpdate }: AddFileProps) {
+function AddFilePanel({
+  driveId,
+  encrypted,
+  actHistoryRef,
+  onDone,
+  onAdd,
+  onActHistoryUpdate,
+  onWrapperRef,
+}: AddFileProps) {
   const { data: addresses } = useAddresses()
   const [phase, setPhase] = useState('')
   const [progress, setProgress] = useState<number | null>(null)
@@ -1576,13 +1589,11 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
         }
       }
 
-      if (encrypted) {
-        // #93: encrypted content is direct-uploaded — confirm the network can
-        // actually serve it (grantees depend on it). Soft outcome: on failure
-        // keep going (pusher may still finish); the hard gate is in ShareModal.
-        setPhase('Confirming availability…')
-        await waitForRetrievable(reference, { attempts: 2, delayMs: 4000 })
-      } else if (uploadTagUid !== undefined) {
+      // NOTE (#93): encrypted content refs are ACT-encrypted POINTERS, not
+      // content addresses — stewardship can't verify them. The availability
+      // check for encrypted drives happens on the public metadata WRAPPER
+      // below (the first thing recipients resolve).
+      if (!encrypted && uploadTagUid !== undefined) {
         // #92 stage 2: follow the tag until the content is on the network.
         setPhase('Propagating to network…')
         setProgress(0)
@@ -1651,6 +1662,12 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
 
           await serverApi.createFeedUpdate(topic, wrapperResult.reference, driveId)
           onActHistoryUpdate?.(uploaded.historyRef)
+          onWrapperRef?.(wrapperResult.reference)
+          // #93: the wrapper is PUBLIC bytes — a real address stewardship can
+          // verify. Confirm the share chain is servable (soft: the ShareModal
+          // gate is the hard stop).
+          setPhase('Confirming availability…')
+          await waitForRetrievable(wrapperResult.reference, { attempts: 2, delayMs: 4000 })
         } catch {
           // Feed update failed — not critical, drive still works without live sharing
         }
@@ -2185,6 +2202,7 @@ export default function Drive() {
     setRepublishMsg('Starting…')
     try {
       await republishDrive({
+        onWrapperRef: ref => driveMetadata.update(driveId, { lastWrapperRef: ref }),
         driveId,
         records: driveRecords,
         actPublisher,
@@ -2392,6 +2410,7 @@ export default function Drive() {
                 customName={customDriveLabels[stamp.batchID]}
                 encrypted={driveMetadata.isEncrypted(stamp.batchID)}
                 granteeCount={driveMetadata.get(stamp.batchID)?.granteeCount}
+                wrapperRef={driveMetadata.get(stamp.batchID)?.lastWrapperRef}
                 onOpen={folderId => {
                   setActiveDriveId(stamp.batchID)
 
@@ -2453,6 +2472,7 @@ export default function Drive() {
                   .filter(r => r.actHistoryRef && r.actPublisher)
                   .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
                 onClose={() => setShowShareModal(null)}
+                onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
                 onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                   driveMetadata.update(showShareModal, {
                     granteeRef,
@@ -2822,6 +2842,9 @@ export default function Drive() {
           onActHistoryUpdate={historyRef => {
             driveMetadata.update(activeDriveId, { actHistoryRef: historyRef })
           }}
+          onWrapperRef={ref => {
+            driveMetadata.update(activeDriveId, { lastWrapperRef: ref })
+          }}
         />
       )}
 
@@ -3012,6 +3035,7 @@ export default function Drive() {
                 .filter(r => r.actHistoryRef && r.actPublisher)
                 .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
               onClose={() => setShowShareModal(null)}
+              onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
               onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                 driveMetadata.update(showShareModal, {
                   granteeRef,

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1164,6 +1164,22 @@ function DriveCard({
     refetchOnWindowFocus: false,
   })
   const showHealthWarning = isShared && healthOk === false
+  const [fixingAvailability, setFixingAvailability] = useState(false)
+  const healthQueryClient = useQueryClient()
+
+  /** #93 fix action: re-push the shared metadata from this node, then re-check. */
+  async function fixAvailability() {
+    if (!wrapperRef || fixingAvailability) return
+    setFixingAvailability(true)
+
+    try {
+      await beeApi.reuploadToNetwork(wrapperRef, stamp.batchID)
+    } catch {
+      // Soft failure — the re-check below reports the true state either way.
+    }
+    await healthQueryClient.invalidateQueries({ queryKey: ['drive-health', stamp.batchID, wrapperRef] })
+    setFixingAvailability(false)
+  }
   const ttlDays = stamp.batchTTL / 86400
   // Critical = days-pill turns red. Matches Figma's 'red at ≤7 days' threshold.
   const isCriticalTtl = stamp.usable && ttlDays > 0 && ttlDays <= 7
@@ -1311,16 +1327,22 @@ function DriveCard({
             </span>
           )}
 
-          {/* #93: newest shared file isn't retrievable from the network */}
+          {/* #93: shared metadata isn't retrievable from the network — the pill
+              carries its own cure: one click re-pushes it from this node. */}
           {showHealthWarning && (
-            <span
-              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0"
+            <button
+              onClick={e => {
+                e.stopPropagation()
+                void fixAvailability()
+              }}
+              disabled={fixingAvailability}
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0 transition-opacity hover:opacity-80 disabled:opacity-60"
               style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
-              title="This drive's shared metadata isn't retrievable from the network right now — recipients may not be able to open the drive. Sharing again (or re-publish) pushes it back."
+              title="Recipients may not be able to open this drive right now — its shared metadata isn't reachable on the network. Click to push it back out from this device."
             >
               <AlertTriangle size={11} />
-              Availability
-            </span>
+              {fixingAvailability ? 'Pushing…' : 'Availability · Fix'}
+            </button>
           )}
 
           {/* Confirming pill */}


### PR DESCRIPTION
The core of the 0.6.0 durability theme — the app now tells the truth about the network.

**#92** — deferred uploads get a second progress stage driven by Bee tags: `Uploading…` (bytes → local node) → `Propagating to network…` (`(seen+synced)/split`). swarm-cli's stall-detection pattern (patience resets on progress). Stalls soften, never fail. ACT uploads are direct → correctly no stage 2.

**#93** — stewardship-based verification at three points: ShareModal **hard gate** (no share link for content the network can't serve), post-upload soft confirm for encrypted content, and an hourly drive-card health pill for shared drives ('Availability' warning + re-publish hint).

Verified: lint 0 errors, types clean, 38 backend + 30 UI tests.

## Test notes (next develop build)
1. Upload a multi-MB folder to a drive → watch two stages; stage 2 should visibly advance and complete
2. Publish a website → same two stages before 'Creating feed…'
3. Encrypted drive: add a file → 'Confirming availability…' phase appears briefly
4. Share modal: share a drive normally → works (the gate should be invisible when things are healthy)
5. Console check: no stewardship spam — health checks fire once per drive per hour max

Closes #92, closes #93