### PR TITLE
Release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.5.4](https://github.com/GasperX93/nook/releases/tag/v0.5.4) (2026-07-16)
+
+### Node reliability
+
+* **Bee supervisor** — the node now recovers on its own: restarts back off after crashes, a crash-loop guard stops endless restart cycles, wedge detection catches a node that is running but frozen, and every node request has a timeout so nothing can hang forever ([#94](https://github.com/GasperX93/nook/issues/94))
+
+### Upload honesty
+
+* **Two-stage upload progress** — uploads now show what is really happening: "Uploading…" (into your node) followed by "Propagating to network…" driven by the node's real sync counters. Slow propagation softens the indicator instead of failing the upload ([#92](https://github.com/GasperX93/nook/issues/92))
+* **Shared content is verified before you share it** — share links are only produced once the network can actually serve the content, encrypted uploads finish with an availability confirmation, and shared drives get an hourly health check with a one-click fix when the network lost their metadata ([#93](https://github.com/GasperX93/nook/issues/93))
+
 ## [0.5.3](https://github.com/GasperX93/nook/releases/tag/v0.5.3) (2026-07-15)
 
 ### Messaging reliability

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/ethersphere/swarm-desktop"
     }
   ],
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Permanent decentralized storage for files, folders and websites",
   "repository": "https://github.com/GasperX93/nook",
   "main": "dist/desktop/src/index.js",

--- a/src/chequebook-monitor.ts
+++ b/src/chequebook-monitor.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from './fetch-timeout'
 import { logger } from './logger'
 import { getMode } from './funding-monitor'
 import { readConfigYaml } from './config'
@@ -21,7 +22,7 @@ function getAuthHeaders(): Record<string, string> {
 }
 
 async function beeGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${getBeeUrl()}${path}`, { headers: getAuthHeaders() })
+  const res = await fetchWithTimeout(`${getBeeUrl()}${path}`, { headers: getAuthHeaders() }, 10_000)
 
   if (!res.ok) throw new Error(`Bee ${path}: ${res.status}`)
 
@@ -29,7 +30,7 @@ async function beeGet<T>(path: string): Promise<T> {
 }
 
 async function beePost<T>(path: string): Promise<T> {
-  const res = await fetch(`${getBeeUrl()}${path}`, { method: 'POST', headers: getAuthHeaders() })
+  const res = await fetchWithTimeout(`${getBeeUrl()}${path}`, { method: 'POST', headers: getAuthHeaders() }, 30_000)
 
   if (!res.ok) throw new Error(`Bee ${path}: ${res.status}`)
 

--- a/src/fetch-timeout.ts
+++ b/src/fetch-timeout.ts
@@ -1,0 +1,7 @@
+/**
+ * fetch with a hard deadline (#94 part B). Bare `fetch()` in the main process
+ * has no timeout — a hung Bee or network leaves requests pending forever.
+ */
+export async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs = 10_000): Promise<Response> {
+  return fetch(url, { ...options, signal: AbortSignal.timeout(timeoutMs) })
+}

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -3,15 +3,55 @@ import { mkdirSync, writeFileSync } from 'fs'
 import { platform } from 'os'
 import { v4 } from 'uuid'
 import { rebuildElectronTray } from './electron'
+import { fetchWithTimeout } from './fetch-timeout'
 import { BeeManager } from './lifecycle'
 import { RotatingLogWriter } from './log-rotator'
 import { logger } from './logger'
 import { checkPath, getLogPath, getPath } from './path'
+import { canAttemptStart, recordExit, recordStart, shouldRestartForWedge } from './supervisor'
+
+/** Liveness probes for the wedge check (see supervisor.ts). */
+const livenessProbes = {
+  getPeerCount: async (): Promise<number | null> => {
+    try {
+      const res = await fetchWithTimeout('http://localhost:1633/peers', {}, 5_000)
+
+      if (!res.ok) return null
+      const data = (await res.json()) as { peers?: unknown[] }
+
+      return Array.isArray(data.peers) ? data.peers.length : null
+    } catch {
+      return null
+    }
+  },
+  hasInternet: async (): Promise<boolean> => {
+    try {
+      const res = await fetchWithTimeout('https://api.github.com', { method: 'HEAD' }, 5_000)
+
+      return res.ok || res.status < 500
+    } catch {
+      return false
+    }
+  },
+}
 
 export function runKeepAliveLoop() {
-  setInterval(() => {
+  setInterval(async () => {
+    const now = Date.now()
+
     if (!BeeManager.isRunning() && BeeManager.shouldRestart()) {
-      runLauncher()
+      if (canAttemptStart(now)) runLauncher()
+
+      return
+    }
+
+    // Sleep/wake wedge detection: a running node with 0 peers for too long
+    // (while the host has internet) never self-recovers — kill it and let the
+    // next tick relaunch with fresh p2p state.
+    if (BeeManager.isRunning() && BeeManager.shouldRestart()) {
+      if (await shouldRestartForWedge(now, livenessProbes)) {
+        BeeManager.kill()
+      }
     }
   }, 10000)
 }
@@ -60,10 +100,12 @@ export async function runLauncher() {
   const subprocess = launchBee(abortController).catch(reason => {
     logger.error(reason)
   })
+  recordStart(Date.now())
   BeeManager.signalRunning(abortController, subprocess)
   rebuildElectronTray()
   await subprocess
   logger.info('Bee subprocess finished running')
+  recordExit(Date.now())
   abortController.abort()
   BeeManager.signalStopped()
   rebuildElectronTray()

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -38,6 +38,16 @@ export const BeeManager = {
       state.abortController.abort()
     }
   },
+  /**
+   * Kill the Bee process WITHOUT clearing the run intention — the keep-alive
+   * loop relaunches it on its next tick. `stop()` is user intent ("keep it
+   * off"); this is supervision ("bounce it"). Used by the wedge restart.
+   */
+  kill: () => {
+    if (state.abortController) {
+      state.abortController.abort()
+    }
+  },
   waitForSigtermToFinish: async () => {
     if (state.process) {
       await state.process

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,8 @@ import { logger, readNookLogs, readBeeLogs, subscribeLogServerRequests } from '.
 import { getPath } from './path'
 import { port } from './port'
 import { getStatus } from './status'
+import { resetCrashLoop } from './supervisor'
+import { fetchWithTimeout } from './fetch-timeout'
 import { swap } from './swap'
 
 const UI_DIST = path.join(__dirname, '..', '..', 'ui')
@@ -80,7 +82,13 @@ export function runServer() {
     }
 
     try {
-      const res = await fetch(url, { method: context.method, headers, body: body as BodyInit | undefined })
+      // Generous deadline: uploads/downloads through the proxy can be large,
+      // but nothing should hang forever (#94).
+      const res = await fetchWithTimeout(
+        url,
+        { method: context.method, headers, body: body as BodyInit | undefined },
+        5 * 60_000,
+      )
 
       context.status = res.status
       // Forward response headers EXCEPT CORS (Koa CORS middleware adds those —
@@ -202,6 +210,7 @@ export function runServer() {
     }
   })
   router.post('/restart', async context => {
+    resetCrashLoop()
     BeeManager.stop()
     await BeeManager.waitForSigtermToFinish()
     runLauncher()

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { isBeeAssetReady } from './downloader'
 import { BeeMode, getMode } from './funding-monitor'
 import { BeeManager } from './lifecycle'
+import { getSupervisorStatus } from './supervisor'
 import { checkPath, getPath } from './path'
 import { readConfigYaml } from './config'
 
@@ -13,6 +14,8 @@ interface Status {
   mode: BeeMode
   /** True when the user intentionally stopped Bee via the tray menu. */
   userStopped: boolean
+  /** True when Bee crashed repeatedly and the supervisor gave up restarting (#94). */
+  crashLoop: boolean
 }
 
 export function getStatus() {
@@ -20,6 +23,7 @@ export function getStatus() {
     assetsReady: isBeeAssetReady(),
     mode: getMode(),
     userStopped: BeeManager.wasEverStarted() && !BeeManager.shouldRestart(),
+    crashLoop: getSupervisorStatus().crashLoop,
   }
 
   if (!checkPath('config.yaml') || !checkPath('data-dir')) {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1,0 +1,151 @@
+import { logger } from './logger'
+
+/**
+ * Bee process supervision policy (#94): restart backoff, crash-loop detection,
+ * and the sleep/wake liveness check. Pure state machine — the keep-alive loop
+ * in launcher.ts drives it and injects probes, so this stays unit-testable.
+ *
+ * Backoff: a run that dies within FAST_CRASH_MS counts as a fast crash;
+ * consecutive fast crashes double the restart delay (10s → 20s → 40s → … 5min
+ * cap). After MAX_FAST_CRASHES the supervisor stops restarting entirely and
+ * flags `crashLoop` (surfaced on /status → UI banner) until the user retries.
+ *
+ * Liveness: a node that reports 0 peers for ZERO_PEERS_LIMIT_MS while the host
+ * has internet is wedged (classic laptop sleep/wake) — kill it so the
+ * keep-alive relaunches with fresh p2p state. Wedge restarts don't climb the
+ * crash ladder: the run's uptime exceeds FAST_CRASH_MS, so the crash counter
+ * resets on exit.
+ */
+
+const BASE_RESTART_DELAY_MS = 10_000
+const MAX_RESTART_DELAY_MS = 5 * 60_000
+/** A run shorter than this counts as a fast crash. */
+const FAST_CRASH_MS = 60_000
+/** Consecutive fast crashes before giving up (crash loop). */
+const MAX_FAST_CRASHES = 5
+/** Don't evaluate liveness until the node has had time to bootstrap. */
+const LIVENESS_GRACE_MS = 5 * 60_000
+/** 0 peers for this long (with internet up) ⇒ wedged. */
+const ZERO_PEERS_LIMIT_MS = 5 * 60_000
+
+interface SupervisorState {
+  consecutiveFastCrashes: number
+  notBeforeMs: number
+  crashLoop: boolean
+  lastStartMs: number | null
+  zeroPeersSinceMs: number | null
+  wedgeRestarts: number
+}
+
+const state: SupervisorState = {
+  consecutiveFastCrashes: 0,
+  notBeforeMs: 0,
+  crashLoop: false,
+  lastStartMs: null,
+  zeroPeersSinceMs: null,
+  wedgeRestarts: 0,
+}
+
+/** May the keep-alive loop attempt a (re)start right now? */
+export function canAttemptStart(nowMs: number): boolean {
+  return !state.crashLoop && nowMs >= state.notBeforeMs
+}
+
+export function recordStart(nowMs: number): void {
+  state.lastStartMs = nowMs
+  state.zeroPeersSinceMs = null
+}
+
+/** Call when a Bee run ends. Uptime decides crash accounting. */
+export function recordExit(nowMs: number): void {
+  const uptime = state.lastStartMs === null ? Number.POSITIVE_INFINITY : nowMs - state.lastStartMs
+
+  if (uptime >= FAST_CRASH_MS) {
+    // Healthy run (or a deliberate wedge restart) — clean slate.
+    state.consecutiveFastCrashes = 0
+    state.notBeforeMs = 0
+
+    return
+  }
+
+  state.consecutiveFastCrashes++
+
+  if (state.consecutiveFastCrashes >= MAX_FAST_CRASHES) {
+    state.crashLoop = true
+    logger.error(
+      `bee crashed ${state.consecutiveFastCrashes} times in a row (uptime < ${FAST_CRASH_MS / 1000}s) — ` +
+        'giving up on automatic restarts. Use Restart in the app to try again.',
+    )
+
+    return
+  }
+
+  const delay = Math.min(BASE_RESTART_DELAY_MS * 2 ** state.consecutiveFastCrashes, MAX_RESTART_DELAY_MS)
+  state.notBeforeMs = nowMs + delay
+  logger.warn(
+    `bee exited after ${Math.round(uptime / 1000)}s (fast crash ${state.consecutiveFastCrashes}/${MAX_FAST_CRASHES}) — ` +
+      `next restart in ${Math.round(delay / 1000)}s`,
+  )
+}
+
+/** User asked for a fresh start (tray Restart / POST /restart) — forgive everything. */
+export function resetCrashLoop(): void {
+  state.consecutiveFastCrashes = 0
+  state.notBeforeMs = 0
+  state.crashLoop = false
+}
+
+export interface LivenessProbes {
+  /** Connected peer count from the local node, or null when unreachable. */
+  getPeerCount: () => Promise<number | null>
+  /** Cheap external reachability check. */
+  hasInternet: () => Promise<boolean>
+}
+
+/**
+ * Evaluate the wedge condition. Returns true when the caller should kill Bee
+ * (the keep-alive loop then relaunches it). Callers invoke this on their tick
+ * only while Bee is running.
+ */
+export async function shouldRestartForWedge(nowMs: number, probes: LivenessProbes): Promise<boolean> {
+  if (state.lastStartMs === null || nowMs - state.lastStartMs < LIVENESS_GRACE_MS) return false
+
+  const peers = await probes.getPeerCount()
+
+  // API unreachable is a different failure (crash detection handles a dead
+  // process); only a live API reporting zero peers arms the wedge timer.
+  if (peers === null || peers > 0) {
+    state.zeroPeersSinceMs = null
+
+    return false
+  }
+
+  if (state.zeroPeersSinceMs === null) {
+    state.zeroPeersSinceMs = nowMs
+
+    return false
+  }
+
+  if (nowMs - state.zeroPeersSinceMs < ZERO_PEERS_LIMIT_MS) return false
+
+  if (!(await probes.hasInternet())) {
+    // Host is offline — nothing a restart can fix; keep waiting.
+    return false
+  }
+
+  state.wedgeRestarts++
+  state.zeroPeersSinceMs = null
+  logger.error(
+    `bee wedged: 0 peers for ${ZERO_PEERS_LIMIT_MS / 60_000}m with internet up — restarting (wedge restart #${state.wedgeRestarts})`,
+  )
+
+  return true
+}
+
+export function getSupervisorStatus(): { crashLoop: boolean; consecutiveFastCrashes: number; wedgeRestarts: number } {
+  return {
+    crashLoop: state.crashLoop,
+    consecutiveFastCrashes: state.consecutiveFastCrashes,
+    wedgeRestarts: state.wedgeRestarts,
+  }
+}

--- a/test/supervisor.spec.ts
+++ b/test/supervisor.spec.ts
@@ -1,0 +1,123 @@
+jest.mock('env-paths', () =>
+  jest.fn().mockImplementation(() => ({
+    data: 'test/data',
+    config: 'test/data',
+    cache: 'test/data',
+    log: 'test/data',
+    temp: 'test/data',
+  })),
+)
+
+import {
+  canAttemptStart,
+  getSupervisorStatus,
+  recordExit,
+  recordStart,
+  resetCrashLoop,
+  shouldRestartForWedge,
+} from '../src/supervisor'
+
+const MIN = 60_000
+
+function probes(peerCount: number | null, internet = true) {
+  return {
+    getPeerCount: async () => peerCount,
+    hasInternet: async () => internet,
+  }
+}
+
+describe('supervisor', () => {
+  beforeEach(() => resetCrashLoop())
+
+  test('healthy run resets crash accounting', () => {
+    let t = 0
+    recordStart(t)
+    recordExit((t += 2 * MIN)) // uptime 2min = healthy
+    expect(canAttemptStart(t)).toBe(true)
+    expect(getSupervisorStatus().consecutiveFastCrashes).toBe(0)
+  })
+
+  test('fast crashes back off exponentially', () => {
+    let t = 0
+    recordStart(t)
+    recordExit((t += 5_000)) // crash 1 → wait 20s
+    expect(canAttemptStart(t + 10_000)).toBe(false)
+    expect(canAttemptStart(t + 21_000)).toBe(true)
+
+    recordStart((t += 21_000))
+    recordExit((t += 5_000)) // crash 2 → wait 40s
+    expect(canAttemptStart(t + 30_000)).toBe(false)
+    expect(canAttemptStart(t + 41_000)).toBe(true)
+  })
+
+  test('a long run after crashes resets the ladder', () => {
+    let t = 0
+    recordStart(t)
+    recordExit((t += 5_000)) // crash 1
+    recordStart((t += 30_000))
+    recordExit((t += 2 * MIN)) // healthy
+    expect(getSupervisorStatus().consecutiveFastCrashes).toBe(0)
+    expect(canAttemptStart(t)).toBe(true)
+  })
+
+  test('5 consecutive fast crashes trip the crash loop; reset forgives', () => {
+    let t = 0
+
+    for (let i = 0; i < 5; i++) {
+      recordStart(t)
+      recordExit((t += 5_000))
+      t += 10 * MIN // wait out any backoff
+    }
+    expect(getSupervisorStatus().crashLoop).toBe(true)
+    expect(canAttemptStart(t)).toBe(false)
+
+    resetCrashLoop()
+    expect(getSupervisorStatus().crashLoop).toBe(false)
+    expect(canAttemptStart(t)).toBe(true)
+  })
+
+  describe('wedge detection', () => {
+    test('no restart during warmup grace', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(2 * MIN, probes(0))).toBe(false)
+    })
+
+    test('0 peers must persist past the limit before restarting', async () => {
+      recordStart(0)
+      // Past grace, first zero-peers observation only arms the timer
+      expect(await shouldRestartForWedge(6 * MIN, probes(0))).toBe(false)
+      // Still within the 5-minute window
+      expect(await shouldRestartForWedge(8 * MIN, probes(0))).toBe(false)
+      // Past the window with internet up → restart
+      expect(await shouldRestartForWedge(12 * MIN, probes(0))).toBe(true)
+    })
+
+    test('peers recovering disarms the timer', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(6 * MIN, probes(0))).toBe(false)
+      expect(await shouldRestartForWedge(8 * MIN, probes(30))).toBe(false) // recovered
+      expect(await shouldRestartForWedge(14 * MIN, probes(0))).toBe(false) // re-arms fresh
+    })
+
+    test('no internet → no restart (nothing to fix)', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(6 * MIN, probes(0, false))).toBe(false)
+      expect(await shouldRestartForWedge(12 * MIN, probes(0, false))).toBe(false)
+    })
+
+    test('unreachable API is not a wedge (crash detection owns that)', async () => {
+      recordStart(0)
+      expect(await shouldRestartForWedge(6 * MIN, probes(null))).toBe(false)
+      expect(await shouldRestartForWedge(12 * MIN, probes(null))).toBe(false)
+    })
+
+    test('after a wedge restart the timer starts clean', async () => {
+      recordStart(0)
+      await shouldRestartForWedge(6 * MIN, probes(0))
+      expect(await shouldRestartForWedge(12 * MIN, probes(0))).toBe(true)
+      // New run
+      recordStart(13 * MIN)
+      expect(await shouldRestartForWedge(19 * MIN, probes(0))).toBe(false) // arms only
+    })
+  })
+})

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nook-ui",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "scripts": {
     "start": "vite --port 3002",

--- a/ui/src/api/bee.ts
+++ b/ui/src/api/bee.ts
@@ -411,6 +411,20 @@ export const beeApi = {
   getTag: async (uid: number): Promise<UploadTag> => beeRequest<UploadTag>(`/tags/${uid}`),
 
   /**
+   * Re-push content to the network from this node's local store (#93 fix
+   * action). Bee stewardship PUT traverses the reference and re-uploads every
+   * chunk with a fresh stamp — the one-call cure when the network can't serve
+   * content this node still holds.
+   */
+  reuploadToNetwork: async (reference: string, stampId: string): Promise<void> => {
+    await beeRequest(`/stewardship/${reference}`, {
+      method: 'PUT',
+      headers: { 'swarm-postage-batch-id': stampId },
+      signal: AbortSignal.timeout(120_000),
+    })
+  },
+
+  /**
    * Is this reference retrievable from the NETWORK (#93)? One stewardship call —
    * Bee attempts an actual retrieval, so treat it as expensive: on-demand and
    * slow-cadence only, never in fast polls.

--- a/ui/src/api/bee.ts
+++ b/ui/src/api/bee.ts
@@ -46,6 +46,92 @@ async function xhrUpload(
   })
 }
 
+/**
+ * Bee upload-session tag (#92). Counters (all in chunks):
+ * `split` = produced by the splitter, `seen` = already known to the network
+ * (dedup), `sent`/`synced` = pushed / receipt-confirmed. For a deferred upload,
+ * `(seen + synced) / split` is the true network-propagation progress — the XHR
+ * progress bar only measures bytes reaching the LOCAL node.
+ */
+export interface UploadTag {
+  uid: number
+  split: number
+  seen: number
+  sent: number
+  synced: number
+}
+
+/**
+ * Poll a tag until the upload is fully propagated (#92). swarm-cli's pattern:
+ * poll every second, and RESET the patience counter whenever progress advances,
+ * so slow networks don't time out spuriously — only genuine stalls do.
+ * Resolves `{ complete: false }` on stall instead of throwing: the content is
+ * safe on the local node and the background pusher keeps working; the caller
+ * should proceed with a soft warning, not fail the upload.
+ */
+export async function waitForTagPropagation(
+  uid: number,
+  onProgress?: (pct: number) => void,
+  opts: { pollMs?: number; maxStalledPolls?: number } = {},
+): Promise<{ complete: boolean; tag: UploadTag | null }> {
+  const pollMs = opts.pollMs ?? 1000
+  const maxStalledPolls = opts.maxStalledPolls ?? 60
+  let best = -1
+  let stalled = 0
+  let tag: UploadTag | null = null
+
+  while (stalled < maxStalledPolls) {
+    try {
+      tag = await beeRequest<UploadTag>(`/tags/${uid}`)
+      const done = tag.seen + tag.synced
+
+      if (tag.split > 0) {
+        onProgress?.(Math.min(Math.round((done / tag.split) * 100), 100))
+
+        if (done >= tag.split) return { complete: true, tag }
+      }
+
+      if (done > best) {
+        best = done
+        stalled = 0
+      } else {
+        stalled++
+      }
+    } catch {
+      stalled++
+    }
+    await new Promise(r => setTimeout(r, pollMs))
+  }
+
+  return { complete: false, tag }
+}
+
+/**
+ * Confirm a reference is retrievable from the network, with patience (#93).
+ * Direct uploads should pass quickly; a just-pushed ref can lag a few seconds.
+ * Returns false after `attempts` failures — callers show a soft warning, they
+ * don't fail the operation (the content may still propagate).
+ */
+export async function waitForRetrievable(
+  reference: string,
+  opts: { attempts?: number; delayMs?: number } = {},
+): Promise<boolean> {
+  const attempts = opts.attempts ?? 3
+  const delayMs = opts.delayMs ?? 4000
+
+  for (let i = 0; i < attempts; i++) {
+    try {
+      if (await beeApi.checkRetrievable(reference)) return true
+    } catch {
+      // stewardship endpoint unavailable/timeout — retry
+    }
+
+    if (i < attempts - 1) await new Promise(r => setTimeout(r, delayMs))
+  }
+
+  return false
+}
+
 async function beeRequest<T>(path: string, options?: RequestInit): Promise<T> {
   const url = `${getBeeUrl()}${path}`
   const response = await fetch(url, options)
@@ -314,11 +400,35 @@ export const beeApi = {
   diluteStamp: async (id: string, depth: number) =>
     beeRequest<{ batchID: string }>(`/stamps/dilute/${id}/${depth}`, { method: 'PATCH' }),
 
+  /** Create an upload-session tag (#92). Pass its uid to an upload to track network propagation. */
+  createTag: async (): Promise<UploadTag> =>
+    beeRequest<UploadTag>('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    }),
+
+  getTag: async (uid: number): Promise<UploadTag> => beeRequest<UploadTag>(`/tags/${uid}`),
+
+  /**
+   * Is this reference retrievable from the NETWORK (#93)? One stewardship call —
+   * Bee attempts an actual retrieval, so treat it as expensive: on-demand and
+   * slow-cadence only, never in fast polls.
+   */
+  checkRetrievable: async (reference: string): Promise<boolean> => {
+    const res = await beeRequest<{ isRetrievable: boolean }>(`/stewardship/${reference}`, {
+      signal: AbortSignal.timeout(30_000),
+    })
+
+    return res.isRetrievable
+  },
+
   uploadFileWithProgress: async (
     file: File,
     stampId: string,
     onProgress?: (pct: number) => void,
     deferred = true,
+    tagUid?: number,
   ): Promise<UploadResult> =>
     xhrUpload(
       `${getBeeUrl()}/bzz`,
@@ -328,6 +438,7 @@ export const beeApi = {
         'swarm-deferred-upload': deferred ? 'true' : 'false',
         'Content-Type': file.type || 'application/octet-stream',
         'Content-Disposition': `inline; filename="${encodeURIComponent(file.name)}"`,
+        ...(tagUid !== undefined ? { 'swarm-tag': String(tagUid) } : {}),
       },
       onProgress,
     ),
@@ -335,7 +446,7 @@ export const beeApi = {
   uploadCollectionWithProgress: async (
     entries: FileEntry[],
     stampId: string,
-    options?: { indexDocument?: string; errorDocument?: string; deferred?: boolean },
+    options?: { indexDocument?: string; errorDocument?: string; deferred?: boolean; tagUid?: number },
     onProgress?: (pct: number) => void,
   ): Promise<UploadResult> => {
     const tar = await createTar(entries)
@@ -350,6 +461,8 @@ export const beeApi = {
     if (options?.indexDocument) headers['swarm-index-document'] = options.indexDocument
 
     if (options?.errorDocument) headers['swarm-error-document'] = options.errorDocument
+
+    if (options?.tagUid !== undefined) headers['swarm-tag'] = String(options.tagUid)
 
     return xhrUpload(`${getBeeUrl()}/bzz`, tar as XMLHttpRequestBodyInit, headers, onProgress)
   },

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -54,6 +54,8 @@ export interface Status {
   address?: string
   /** True when the user intentionally stopped Bee via the tray menu. */
   userStopped?: boolean
+  /** True when Bee crashed repeatedly and automatic restarts are paused (#94). */
+  crashLoop?: boolean
 }
 
 export interface Peers {

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useDisconnect } from 'wagmi'
 import { weiToDai } from '../api/bee'
-import { useBeeHealth, usePeers, useStamps, useStatus, useWallet } from '../api/queries'
+import { useBeeHealth, usePeers, useRestart, useStamps, useStatus, useWallet } from '../api/queries'
 import { useInboxPolling } from '../hooks/useInboxPolling'
 import { primeCricketAudio } from '../lib/cricket'
 import { loadReadCursors, loadThreads, totalUnread } from '../notify/messages'
@@ -122,6 +122,7 @@ export default function Layout() {
   const { isError: beeOffline, isPending: beeChecking, isSuccess: beeOnline } = useBeeHealth()
   const { data: peers } = usePeers()
   const { data: status } = useStatus()
+  const restartBee = useRestart()
   const { data: stamps, isSuccess: stampsLoaded } = useStamps()
   const { data: wallet, isSuccess: walletLoaded } = useWallet()
   const { devMode, onboardingCompleted, setOnboardingCompleted } = useAppStore()
@@ -339,8 +340,28 @@ export default function Layout() {
             </div>
           )}
 
+          {/* Crash loop — the supervisor gave up restarting Bee (#94) */}
+          {status?.crashLoop && !showOnboarding && (
+            <div
+              className="flex items-center gap-2 px-4 py-2.5 text-xs shrink-0"
+              style={{ backgroundColor: 'rgba(239,68,68,0.1)', borderBottom: '1px solid rgba(239,68,68,0.2)' }}
+            >
+              <AlertTriangle size={13} className="shrink-0" style={{ color: '#ef4444' }} />
+              <span style={{ color: '#ef4444' }}>
+                Bee keeps crashing — automatic restarts paused. Check the Logs tab.{' '}
+                <button
+                  onClick={() => restartBee.mutate()}
+                  className="underline font-semibold"
+                  style={{ color: '#ef4444' }}
+                >
+                  Try again
+                </button>
+              </span>
+            </div>
+          )}
+
           {/* Bee down — only shown after it was previously online */}
-          {showDown && !showOnboarding && (
+          {showDown && !status?.crashLoop && !showOnboarding && (
             <div
               className="flex items-center gap-2 px-4 py-2.5 text-xs shrink-0"
               style={{ backgroundColor: 'rgba(239,68,68,0.1)', borderBottom: '1px solid rgba(239,68,68,0.2)' }}

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -60,6 +60,12 @@ interface ShareModalProps {
   onRepublish?: () => void
   /** Latest public wrapper ref after a metadata refresh (#93 health checks). */
   onWrapperRef?: (ref: string) => void
+  /**
+   * Authoritative grantee count (including owner), reported whenever the list
+   * is loaded from the node. Self-heals the cached count on the drive card —
+   * grant/revoke math can drift when operations race the async list load.
+   */
+  onGranteeCount?: (n: number) => void
 }
 
 function isValidPublicKey(key: string): boolean {
@@ -89,6 +95,7 @@ export default function ShareModal({
   republishMsg,
   onRepublish,
   onWrapperRef,
+  onGranteeCount,
 }: ShareModalProps) {
   const { signer } = useDerivedKey()
   const { data: walletClient } = useWalletClient()
@@ -198,7 +205,11 @@ export default function ShareModal({
     setLoadedGrantees(true)
     serverApi
       .getGrantees(granteeRef)
-      .then(result => setGrantees(result.grantees))
+      .then(result => {
+        setGrantees(result.grantees)
+        // Server list is the truth — heal the drive card's cached count.
+        onGranteeCount?.(result.grantees.length)
+      })
       .catch(() => setGrantees([]))
   }
 

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -208,7 +208,10 @@ export default function ShareModal({
       .then(result => {
         setGrantees(result.grantees)
         // Server list is the truth — heal the drive card's cached count.
-        onGranteeCount?.(result.grantees.length)
+        // Count OTHER people explicitly: depending on how a drive was created
+        // its list may or may not contain the owner's own key, so raw list
+        // length is off-by-one for some drives. Stored convention: others + 1.
+        onGranteeCount?.(result.grantees.filter(g => !isMyKey(g)).length + 1)
       })
       .catch(() => setGrantees([]))
   }
@@ -360,7 +363,7 @@ export default function ShareModal({
       onUpdate({
         granteeRef: result.ref,
         historyRef: result.historyRef,
-        granteeCount: grantees.length + 1,
+        granteeCount: [...grantees, key].filter(g => !isMyKey(g)).length + 1,
       })
 
       // Refresh from localStorage so a newly-added contact is matched for the
@@ -408,7 +411,7 @@ export default function ShareModal({
       onUpdate({
         granteeRef: result.ref,
         historyRef: result.historyRef,
-        granteeCount: grantees.length - 1,
+        granteeCount: grantees.filter(g => g !== key && !isMyKey(g)).length + 1,
         keyRotated: true,
       })
     } catch (err) {

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from 'react'
 import { getWalletClient, switchChain } from '@wagmi/core'
 import { useWalletClient } from 'wagmi'
 
-import { topicFromString } from '../api/bee'
+import { topicFromString, waitForRetrievable } from '../api/bee'
 import { serverApi } from '../api/server'
 import { bytesToHex, hexToBytes } from '../lib/hex'
 import { useDerivedKey } from '../hooks/useDerivedKey'
@@ -435,6 +435,13 @@ export default function ShareModal({
     const wrapperResult = await serverApi.uploadRawBytes(stampId, wrapper)
 
     await serverApi.createFeedUpdate(topic, wrapperResult.reference, stampId)
+
+    // #93: never hand out a link to content the network can't serve. The
+    // wrapper is what the recipient's feed read resolves first — verify it's
+    // actually retrievable (uploads are direct, so this should pass fast).
+    if (!(await waitForRetrievable(wrapperResult.reference, { attempts: 3, delayMs: 4000 }))) {
+      throw new Error("Content hasn't reached the network yet — wait a moment and try sharing again.")
+    }
 
     return buildShareLink({
       feedTopic: topic,

--- a/ui/src/components/ShareModal.tsx
+++ b/ui/src/components/ShareModal.tsx
@@ -58,6 +58,8 @@ interface ShareModalProps {
   republishMsg?: string | null
   /** Re-encrypt + re-upload this drive's files under the current key. */
   onRepublish?: () => void
+  /** Latest public wrapper ref after a metadata refresh (#93 health checks). */
+  onWrapperRef?: (ref: string) => void
 }
 
 function isValidPublicKey(key: string): boolean {
@@ -86,6 +88,7 @@ export default function ShareModal({
   republishing,
   republishMsg,
   onRepublish,
+  onWrapperRef,
 }: ShareModalProps) {
   const { signer } = useDerivedKey()
   const { data: walletClient } = useWalletClient()
@@ -442,6 +445,7 @@ export default function ShareModal({
     if (!(await waitForRetrievable(wrapperResult.reference, { attempts: 3, delayMs: 4000 }))) {
       throw new Error("Content hasn't reached the network yet — wait a moment and try sharing again.")
     }
+    onWrapperRef?.(wrapperResult.reference)
 
     return buildShareLink({
       feedTopic: topic,

--- a/ui/src/hooks/useDriveMetadata.ts
+++ b/ui/src/hooks/useDriveMetadata.ts
@@ -34,6 +34,13 @@ export interface LocalDriveMetadata {
    * signer: the drive can be re-anchored from bpub to this wpub.
    */
   creatorWpub?: string
+  /**
+   * Latest metadata-feed WRAPPER reference (public bytes). This is the first
+   * thing a share recipient resolves (feed → wrapper → metadata), and — unlike
+   * the ACT-encrypted file refs — it's a real content address that stewardship
+   * can verify. Used by the drive-health check (#93).
+   */
+  lastWrapperRef?: string
 }
 
 function load(): Record<string, LocalDriveMetadata> {

--- a/ui/src/hooks/useUpload.ts
+++ b/ui/src/hooks/useUpload.ts
@@ -1,4 +1,4 @@
-import { beeApi, topicFromString } from '../api/bee'
+import { beeApi, topicFromString, waitForTagPropagation } from '../api/bee'
 import { serverApi } from '../api/server'
 import { detectIndexDocument, type FileEntry } from '../utils/directory'
 import { useUploadHistory } from './useUploadHistory'
@@ -84,7 +84,7 @@ export function useUpload() {
     // even after the stamp reports as usable via REST.
     let currentHistoryRef = actHistoryRef
 
-    async function doUpload(attempt: number): Promise<{ reference: string; historyAddress?: string }> {
+    async function doUpload(attempt: number): Promise<{ reference: string; historyAddress?: string; tagUid?: number }> {
       if (attempt > 1) {
         onPhase?.(`Finalising storage… (retry ${attempt - 1})`)
         await new Promise(r => setTimeout(r, 10000))
@@ -105,31 +105,48 @@ export function useUpload() {
         return beeApi.uploadCollectionWithACT(entries, driveId, currentHistoryRef, opts, pct => onProgress?.(pct))
       }
 
-      // Regular (non-encrypted) upload
-      if (type === 'file') {
-        const res = await beeApi.uploadFileWithProgress(entries[0].file, driveId, pct => onProgress?.(pct), true)
+      // Regular (non-encrypted) upload — deferred, so bytes land on the LOCAL
+      // node first. A tag (#92) tracks the real network propagation afterwards.
+      let tagUid: number | undefined
 
-        return { reference: res.reference }
+      try {
+        tagUid = (await beeApi.createTag()).uid
+      } catch {
+        // Tags unavailable — upload proceeds without stage-2 progress.
+      }
+
+      if (type === 'file') {
+        const res = await beeApi.uploadFileWithProgress(
+          entries[0].file,
+          driveId,
+          pct => onProgress?.(pct),
+          true,
+          tagUid,
+        )
+
+        return { reference: res.reference, tagUid }
       }
 
       const autoIndex = indexDocument ?? detectIndexDocument(entries) ?? 'index.html'
       const opts =
         type === 'website'
-          ? { indexDocument: autoIndex, errorDocument: '404.html', deferred: true }
-          : { deferred: true }
+          ? { indexDocument: autoIndex, errorDocument: '404.html', deferred: true, tagUid }
+          : { deferred: true, tagUid }
       const res = await beeApi.uploadCollectionWithProgress(entries, driveId, opts, pct => onProgress?.(pct))
 
-      return { reference: res.reference }
+      return { reference: res.reference, tagUid }
     }
 
     let reference!: string
     let uploadHistoryAddress: string | undefined
+    let uploadTagUid: number | undefined
 
     for (let attempt = 1; attempt <= 8; attempt++) {
       try {
         const result = await doUpload(attempt)
         reference = result.reference
         uploadHistoryAddress = result.historyAddress
+        uploadTagUid = result.tagUid
 
         // Update history ref for next upload in same session
         if (uploadHistoryAddress) currentHistoryRef = uploadHistoryAddress
@@ -142,6 +159,21 @@ export function useUpload() {
 
         if (attempt === 8) throw err
         // stamp issuer may not be loaded yet — retry
+      }
+    }
+
+    // Stage 2 (#92): the XHR bar only measured bytes reaching the LOCAL node.
+    // For deferred uploads, follow the tag until the content is actually on the
+    // network. A stall is a soft outcome — the background pusher keeps working,
+    // so warn in the phase text but never fail the upload here.
+    if (uploadTagUid !== undefined && !encrypted) {
+      onPhase?.('Propagating to network…')
+      onProgress?.(0)
+      const { complete } = await waitForTagPropagation(uploadTagUid, pct => onProgress?.(pct))
+
+      if (!complete) {
+        onPhase?.('Still propagating in the background…')
+        await new Promise(r => setTimeout(r, 1500))
       }
     }
 

--- a/ui/src/lib/republish.ts
+++ b/ui/src/lib/republish.ts
@@ -32,10 +32,12 @@ export interface RepublishDeps {
   onRecordUpdate: (id: string, changes: Partial<UploadRecord>) => void
   /** Persist the drive's new latest history ref. */
   onHistoryUpdate: (historyRef: string) => void
+  /** Latest public wrapper ref after the metadata rebuild (#93 health checks). */
+  onWrapperRef?: (ref: string) => void
 }
 
 export async function republishDrive(deps: RepublishDeps): Promise<void> {
-  const { driveId, records, actPublisher, onProgress, onRecordUpdate, onHistoryUpdate } = deps
+  const { driveId, records, actPublisher, onProgress, onRecordUpdate, onHistoryUpdate, onWrapperRef } = deps
 
   // Only single files are round-trippable via ACT download/upload here.
   // (Folders/websites are collections — re-publishing those is a follow-up.)
@@ -76,4 +78,5 @@ export async function republishDrive(deps: RepublishDeps): Promise<void> {
 
   await serverApi.createFeedUpdate(topic, wrapperResult.reference, driveId)
   onHistoryUpdate(uploaded.historyRef)
+  onWrapperRef?.(wrapperResult.reference)
 }

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1137,16 +1137,28 @@ function DriveCard({
   const usagePct = Math.min(fillRatio * 100, 100)
   const utilizationPct = Math.round(fillRatio * 100)
   const isFull = fillRatio >= 1
-  // #93: slow-cadence health check for SHARED drives — can the network serve
-  // the newest file? Stewardship triggers a real retrieval, so this is gated to
-  // shared+encrypted drives only, one file, refreshed at most hourly.
+  // #93: slow-cadence health check for SHARED drives. Target = the PUBLIC
+  // metadata wrapper (the first hop recipients resolve) — ACT file refs are
+  // encrypted pointers that stewardship cannot verify, so drives without a
+  // recorded wrapper ref are simply not checked.
   const isShared = Boolean(encrypted && granteeCount && granteeCount > 1)
-  const newestRef = records.length > 0 ? records[records.length - 1].hash : undefined
   const { data: healthOk } = useQuery({
-    queryKey: ['drive-health', stamp.batchID, newestRef],
-    queryFn: async () => beeApi.checkRetrievable(newestRef!),
-    enabled: isShared && Boolean(newestRef) && stamp.usable,
-    staleTime: 60 * 60 * 1000,
+    queryKey: ['drive-health', stamp.batchID, wrapperRef],
+    // Two-strike rule: bee's IsRetrievable retrieves ONLY from the network
+    // (steward netGetter — bypasses the local store), which is the right
+    // question but flaky for freshly-pushed content on a light node. Only
+    // report unhealthy when two checks ~25s apart BOTH fail.
+    queryFn: async () => {
+      if (await beeApi.checkRetrievable(wrapperRef!)) return true
+      await new Promise(r => setTimeout(r, 25_000))
+
+      return beeApi.checkRetrievable(wrapperRef!)
+    },
+    enabled: isShared && Boolean(wrapperRef) && stamp.usable,
+    // Red verdicts re-check every 10 minutes so the pill clears itself once
+    // the network catches up; healthy drives only re-check hourly.
+    refetchInterval: query => (query.state.data === false ? 10 * 60 * 1000 : 60 * 60 * 1000),
+    staleTime: 10 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
     retry: false,
     refetchOnWindowFocus: false,

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -2473,6 +2473,7 @@ export default function Drive() {
                   .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
                 onClose={() => setShowShareModal(null)}
                 onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
+                onGranteeCount={n => driveMetadata.update(showShareModal, { granteeCount: n })}
                 onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                   driveMetadata.update(showShareModal, {
                     granteeRef,
@@ -3036,6 +3037,7 @@ export default function Drive() {
                 .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
               onClose={() => setShowShareModal(null)}
               onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
+              onGranteeCount={n => driveMetadata.update(showShareModal, { granteeCount: n })}
               onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                 driveMetadata.update(showShareModal, {
                   granteeRef,

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   ArrowLeft,
   Check,
   ChevronDown,
@@ -26,7 +27,7 @@ import {
   Users,
   X,
 } from 'lucide-react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import React, { useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useAccount } from 'wagmi'
@@ -41,6 +42,8 @@ import {
   SIZE_PRESETS,
   stampFillRatio,
   topicFromString,
+  waitForRetrievable,
+  waitForTagPropagation,
   type Stamp,
 } from '../api/bee'
 import { serverApi } from '../api/server'
@@ -1131,6 +1134,21 @@ function DriveCard({
   const usagePct = Math.min(fillRatio * 100, 100)
   const utilizationPct = Math.round(fillRatio * 100)
   const isFull = fillRatio >= 1
+  // #93: slow-cadence health check for SHARED drives — can the network serve
+  // the newest file? Stewardship triggers a real retrieval, so this is gated to
+  // shared+encrypted drives only, one file, refreshed at most hourly.
+  const isShared = Boolean(encrypted && granteeCount && granteeCount > 1)
+  const newestRef = records.length > 0 ? records[records.length - 1].hash : undefined
+  const { data: healthOk } = useQuery({
+    queryKey: ['drive-health', stamp.batchID, newestRef],
+    queryFn: async () => beeApi.checkRetrievable(newestRef!),
+    enabled: isShared && Boolean(newestRef) && stamp.usable,
+    staleTime: 60 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+  const showHealthWarning = isShared && healthOk === false
   const ttlDays = stamp.batchTTL / 86400
   // Critical = days-pill turns red. Matches Figma's 'red at ≤7 days' threshold.
   const isCriticalTtl = stamp.usable && ttlDays > 0 && ttlDays <= 7
@@ -1275,6 +1293,18 @@ function DriveCard({
             >
               <Lock size={12} />
               Encrypted{granteeCount && granteeCount > 1 ? ` · ${granteeCount - 1} shared` : ''}
+            </span>
+          )}
+
+          {/* #93: newest shared file isn't retrievable from the network */}
+          {showHealthWarning && (
+            <span
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0"
+              style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
+              title="The newest file in this drive isn't retrievable from the network right now — recipients may not be able to open it. Re-publish can push it again."
+            >
+              <AlertTriangle size={11} />
+              Availability
             </span>
           )}
 
@@ -1476,7 +1506,9 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
 
       let currentHistoryRef = actHistoryRef
 
-      async function doUpload(attempt: number): Promise<{ reference: string; historyAddress?: string }> {
+      async function doUpload(
+        attempt: number,
+      ): Promise<{ reference: string; historyAddress?: string; tagUid?: number }> {
         if (attempt > 1) {
           setPhase(`Finalising storage… (retry ${attempt - 1})`)
           await new Promise(r => setTimeout(r, 5000))
@@ -1494,27 +1526,45 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
           )
         }
 
-        if (type === 'file') {
-          const res = await beeApi.uploadFileWithProgress(entries[0].file, driveId, pct => setProgress(pct))
+        // Regular (deferred) upload — a tag (#92) tracks network propagation
+        // after the XHR bar (which only measures bytes to the LOCAL node).
+        let tagUid: number | undefined
 
-          return { reference: res.reference }
+        try {
+          tagUid = (await beeApi.createTag()).uid
+        } catch {
+          // Tags unavailable — proceed without stage-2 progress.
         }
 
-        const res = await beeApi.uploadCollectionWithProgress(uploadEntries, driveId, { indexDocument }, pct =>
+        if (type === 'file') {
+          const res = await beeApi.uploadFileWithProgress(
+            entries[0].file,
+            driveId,
+            pct => setProgress(pct),
+            true,
+            tagUid,
+          )
+
+          return { reference: res.reference, tagUid }
+        }
+
+        const res = await beeApi.uploadCollectionWithProgress(uploadEntries, driveId, { indexDocument, tagUid }, pct =>
           setProgress(pct),
         )
 
-        return { reference: res.reference }
+        return { reference: res.reference, tagUid }
       }
 
       let reference!: string
       let uploadHistoryAddress: string | undefined
+      let uploadTagUid: number | undefined
 
       for (let attempt = 1; attempt <= 4; attempt++) {
         try {
           const result = await doUpload(attempt)
           reference = result.reference
           uploadHistoryAddress = result.historyAddress
+          uploadTagUid = result.tagUid
 
           if (uploadHistoryAddress) {
             currentHistoryRef = uploadHistoryAddress
@@ -1524,6 +1574,21 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
         } catch (err) {
           if (attempt === 4) throw err
         }
+      }
+
+      if (encrypted) {
+        // #93: encrypted content is direct-uploaded — confirm the network can
+        // actually serve it (grantees depend on it). Soft outcome: on failure
+        // keep going (pusher may still finish); the hard gate is in ShareModal.
+        setPhase('Confirming availability…')
+        await waitForRetrievable(reference, { attempts: 2, delayMs: 4000 })
+      } else if (uploadTagUid !== undefined) {
+        // #92 stage 2: follow the tag until the content is on the network.
+        setPhase('Propagating to network…')
+        setProgress(0)
+        const { complete } = await waitForTagPropagation(uploadTagUid, pct => setProgress(pct))
+
+        if (!complete) setPhase('Still propagating in the background…')
       }
 
       setProgress(null)

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1078,6 +1078,8 @@ interface DriveCardProps {
   customName?: string
   encrypted?: boolean
   granteeCount?: number
+  /** Latest public metadata-wrapper ref — the health-check target (#93). */
+  wrapperRef?: string
   onOpen: (folderId?: string) => void
   onExtend: () => void
   onShare?: () => void
@@ -1109,6 +1111,7 @@ function DriveCard({
   onSetENS,
   encrypted,
   granteeCount,
+  wrapperRef,
   onShare,
   onMoveToFolder,
 }: DriveCardProps) {
@@ -1301,7 +1304,7 @@ function DriveCard({
             <span
               className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0"
               style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
-              title="The newest file in this drive isn't retrievable from the network right now — recipients may not be able to open it. Re-publish can push it again."
+              title="This drive's shared metadata isn't retrievable from the network right now — recipients may not be able to open the drive. Sharing again (or re-publish) pushes it back."
             >
               <AlertTriangle size={11} />
               Availability
@@ -1465,6 +1468,8 @@ interface AddFileProps {
   onDone: () => void
   onAdd: (record: UploadRecord) => void
   onActHistoryUpdate?: (historyRef: string) => void
+  /** Latest public wrapper ref after the metadata feed update (#93 health checks). */
+  onWrapperRef?: (ref: string) => void
 }
 
 function generateFolderIndex(name: string, entries: FileEntry[]): FileEntry {
@@ -1481,7 +1486,15 @@ ${rows}
   return { path: '_index.html', file: new FileClass([html], '_index.html', { type: 'text/html' }) }
 }
 
-function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActHistoryUpdate }: AddFileProps) {
+function AddFilePanel({
+  driveId,
+  encrypted,
+  actHistoryRef,
+  onDone,
+  onAdd,
+  onActHistoryUpdate,
+  onWrapperRef,
+}: AddFileProps) {
   const { data: addresses } = useAddresses()
   const [phase, setPhase] = useState('')
   const [progress, setProgress] = useState<number | null>(null)
@@ -1576,13 +1589,11 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
         }
       }
 
-      if (encrypted) {
-        // #93: encrypted content is direct-uploaded — confirm the network can
-        // actually serve it (grantees depend on it). Soft outcome: on failure
-        // keep going (pusher may still finish); the hard gate is in ShareModal.
-        setPhase('Confirming availability…')
-        await waitForRetrievable(reference, { attempts: 2, delayMs: 4000 })
-      } else if (uploadTagUid !== undefined) {
+      // NOTE (#93): encrypted content refs are ACT-encrypted POINTERS, not
+      // content addresses — stewardship can't verify them. The availability
+      // check for encrypted drives happens on the public metadata WRAPPER
+      // below (the first thing recipients resolve).
+      if (!encrypted && uploadTagUid !== undefined) {
         // #92 stage 2: follow the tag until the content is on the network.
         setPhase('Propagating to network…')
         setProgress(0)
@@ -1651,6 +1662,12 @@ function AddFilePanel({ driveId, encrypted, actHistoryRef, onDone, onAdd, onActH
 
           await serverApi.createFeedUpdate(topic, wrapperResult.reference, driveId)
           onActHistoryUpdate?.(uploaded.historyRef)
+          onWrapperRef?.(wrapperResult.reference)
+          // #93: the wrapper is PUBLIC bytes — a real address stewardship can
+          // verify. Confirm the share chain is servable (soft: the ShareModal
+          // gate is the hard stop).
+          setPhase('Confirming availability…')
+          await waitForRetrievable(wrapperResult.reference, { attempts: 2, delayMs: 4000 })
         } catch {
           // Feed update failed — not critical, drive still works without live sharing
         }
@@ -2185,6 +2202,7 @@ export default function Drive() {
     setRepublishMsg('Starting…')
     try {
       await republishDrive({
+        onWrapperRef: ref => driveMetadata.update(driveId, { lastWrapperRef: ref }),
         driveId,
         records: driveRecords,
         actPublisher,
@@ -2392,6 +2410,7 @@ export default function Drive() {
                 customName={customDriveLabels[stamp.batchID]}
                 encrypted={driveMetadata.isEncrypted(stamp.batchID)}
                 granteeCount={driveMetadata.get(stamp.batchID)?.granteeCount}
+                wrapperRef={driveMetadata.get(stamp.batchID)?.lastWrapperRef}
                 onOpen={folderId => {
                   setActiveDriveId(stamp.batchID)
 
@@ -2453,6 +2472,7 @@ export default function Drive() {
                   .filter(r => r.actHistoryRef && r.actPublisher)
                   .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
                 onClose={() => setShowShareModal(null)}
+                onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
                 onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                   driveMetadata.update(showShareModal, {
                     granteeRef,
@@ -2822,6 +2842,9 @@ export default function Drive() {
           onActHistoryUpdate={historyRef => {
             driveMetadata.update(activeDriveId, { actHistoryRef: historyRef })
           }}
+          onWrapperRef={ref => {
+            driveMetadata.update(activeDriveId, { lastWrapperRef: ref })
+          }}
         />
       )}
 
@@ -3012,6 +3035,7 @@ export default function Drive() {
                 .filter(r => r.actHistoryRef && r.actPublisher)
                 .map(r => ({ name: r.name, reference: r.hash, historyRef: r.actHistoryRef!, size: r.size }))}
               onClose={() => setShowShareModal(null)}
+              onWrapperRef={ref => driveMetadata.update(showShareModal, { lastWrapperRef: ref })}
               onUpdate={({ granteeRef, historyRef, granteeCount, keyRotated }) => {
                 driveMetadata.update(showShareModal, {
                   granteeRef,

--- a/ui/src/pages/Drive.tsx
+++ b/ui/src/pages/Drive.tsx
@@ -1164,6 +1164,22 @@ function DriveCard({
     refetchOnWindowFocus: false,
   })
   const showHealthWarning = isShared && healthOk === false
+  const [fixingAvailability, setFixingAvailability] = useState(false)
+  const healthQueryClient = useQueryClient()
+
+  /** #93 fix action: re-push the shared metadata from this node, then re-check. */
+  async function fixAvailability() {
+    if (!wrapperRef || fixingAvailability) return
+    setFixingAvailability(true)
+
+    try {
+      await beeApi.reuploadToNetwork(wrapperRef, stamp.batchID)
+    } catch {
+      // Soft failure — the re-check below reports the true state either way.
+    }
+    await healthQueryClient.invalidateQueries({ queryKey: ['drive-health', stamp.batchID, wrapperRef] })
+    setFixingAvailability(false)
+  }
   const ttlDays = stamp.batchTTL / 86400
   // Critical = days-pill turns red. Matches Figma's 'red at ≤7 days' threshold.
   const isCriticalTtl = stamp.usable && ttlDays > 0 && ttlDays <= 7
@@ -1311,16 +1327,22 @@ function DriveCard({
             </span>
           )}
 
-          {/* #93: newest shared file isn't retrievable from the network */}
+          {/* #93: shared metadata isn't retrievable from the network — the pill
+              carries its own cure: one click re-pushes it from this node. */}
           {showHealthWarning && (
-            <span
-              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0"
+            <button
+              onClick={e => {
+                e.stopPropagation()
+                void fixAvailability()
+              }}
+              disabled={fixingAvailability}
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-semibold shrink-0 transition-opacity hover:opacity-80 disabled:opacity-60"
               style={{ backgroundColor: 'rgba(239,68,68,0.12)', color: '#ef4444' }}
-              title="This drive's shared metadata isn't retrievable from the network right now — recipients may not be able to open the drive. Sharing again (or re-publish) pushes it back."
+              title="Recipients may not be able to open this drive right now — its shared metadata isn't reachable on the network. Click to push it back out from this device."
             >
               <AlertTriangle size={11} />
-              Availability
-            </span>
+              {fixingAvailability ? 'Pushing…' : 'Availability · Fix'}
+            </button>
           )}
 
           {/* Confirming pill */}


### PR DESCRIPTION
## 0.5.4 — node reliability + upload honesty

### Node reliability
- **Bee supervisor** (#94): crash backoff, crash-loop guard, wedge detection, request timeouts

### Upload honesty
- **Two-stage upload progress** (#92): real network propagation stage driven by sync counters
- **Shared-content verification** (#93): share-link gate, encrypted-upload confirmation, hourly drive health check with one-click fix

All three tested on the develop build (incl. overnight sleep/wake with the supervisor). Pre-flight: lint 0 errors, types clean, 38 backend + 30 UI tests, package-locks free of ephemeral registry URLs.

Reclaimable drives (#99) intentionally NOT included — that headlines 0.6.0.